### PR TITLE
f2fs iomap 支持large folios开发分支

### DIFF
--- a/fs/f2fs/Kconfig
+++ b/fs/f2fs/Kconfig
@@ -150,3 +150,8 @@ config F2FS_UNFAIR_RWSEM
 	help
 	  Use unfair rw_semaphore, if system configured IO priority by block
 	  cgroup.
+config F2FS_IOMAP_FOLIO_STATE
+	bool "F2FS folio per-block I/O state tracking"
+	depends on F2FS_FS && FS_IOMAP
+	help
+	  Enable per-block I/O state tracking (uptodate, dirty) for folios using a custom structure that embeds iomap_folio_state.

--- a/fs/f2fs/Makefile
+++ b/fs/f2fs/Makefile
@@ -10,3 +10,4 @@ f2fs-$(CONFIG_F2FS_FS_POSIX_ACL) += acl.o
 f2fs-$(CONFIG_FS_VERITY) += verity.o
 f2fs-$(CONFIG_F2FS_FS_COMPRESSION) += compress.o
 f2fs-$(CONFIG_F2FS_IOSTAT) += iostat.o
+f2fs-$(CONFIG_F2FS_IOMAP_FOLIO_STATE) += f2fs_ifs.o

--- a/fs/f2fs/checkpoint.c
+++ b/fs/f2fs/checkpoint.c
@@ -19,6 +19,7 @@
 #include "node.h"
 #include "segment.h"
 #include "iostat.h"
+#include "f2fs_ifs.h"
 #include <trace/events/f2fs.h>
 
 #define DEFAULT_CHECKPOINT_IOPRIO (IOPRIO_PRIO_VALUE(IOPRIO_CLASS_RT, 3))
@@ -492,7 +493,7 @@ static bool f2fs_dirty_meta_folio(struct address_space *mapping,
 		folio_mark_uptodate(folio);
 	if (filemap_dirty_folio(mapping, folio)) {
 		inc_page_count(F2FS_M_SB(mapping), F2FS_DIRTY_META);
-		set_page_private_reference(&folio->page);
+		f2fs_set_folio_private_reference(folio);
 		return true;
 	}
 	return false;
@@ -1051,7 +1052,7 @@ void f2fs_update_dirty_folio(struct inode *inode, struct folio *folio)
 	inode_inc_dirty_pages(inode);
 	spin_unlock(&sbi->inode_lock[type]);
 
-	set_page_private_reference(&folio->page);
+	f2fs_set_folio_private_reference(folio);
 }
 
 void f2fs_remove_dirty_inode(struct inode *inode)

--- a/fs/f2fs/compress.c
+++ b/fs/f2fs/compress.c
@@ -62,13 +62,29 @@ static unsigned int offset_in_cluster(struct compress_ctx *cc, pgoff_t index)
 {
 	return index & (cc->cluster_size - 1);
 }
-
-static pgoff_t cluster_idx(struct compress_ctx *cc, pgoff_t index)
+inline unsigned int offset_i_in_cluster(struct inode*inode,pgoff_t index)
+{
+	return index & (F2FS_I(inode)->i_cluster_size - 1);
+}
+/*Mychange:remove static*/
+inline pgoff_t cluster_idx(struct compress_ctx *cc, pgoff_t index)
 {
 	return index >> cc->log_cluster_size;
 }
-
-static pgoff_t start_idx_of_cluster(struct compress_ctx *cc)
+inline pgoff_t end_idx_of_cluster(struct compress_ctx *cc, pgoff_t index)
+{
+	/*This is the end idx in page index of cluster*/
+	return (cluster_idx(cc, index)<<cc->log_cluster_size) + (cc->cluster_size - 1);
+}
+inline pgoff_t cluster_i_idx(struct inode*inode,pgoff_t index)
+{
+	return index >> F2FS_I(inode)->i_log_cluster_size;
+}
+inline pgoff_t i_end_idx_of_cluster(struct inode*inode,pgoff_t index)
+{
+	return (cluster_i_idx(inode, index)<<F2FS_I(inode)->i_log_cluster_size) + (F2FS_I(inode)->i_cluster_size - 1);
+}
+pgoff_t start_idx_of_cluster(struct compress_ctx *cc)
 {
 	return cc->cluster_idx << cc->log_cluster_size;
 }
@@ -112,14 +128,20 @@ static void f2fs_set_compressed_page(struct page *page,
 static void f2fs_drop_rpages(struct compress_ctx *cc, int len, bool unlock)
 {
 	int i;
-
-	for (i = 0; i < len; i++) {
-		if (!cc->rpages[i])
+	unsigned int num_to_skip = 0;
+	for (i = 0; i < len; i += num_to_skip) {
+		if (!cc->rpages[i]) {
+			num_to_skip = 1;
 			continue;
+		}
+		struct folio *folio = page_folio(cc->rpages[i]);
 		if (unlock)
-			unlock_page(cc->rpages[i]);
+			folio_unlock(folio);
 		else
-			put_page(cc->rpages[i]);
+			folio_put(folio);
+		num_to_skip = min_t(unsigned int,folio_nr_pages(folio) -
+					  folio_page_idx(folio, cc->rpages[i]),
+				  len - i);
 	}
 }
 
@@ -134,16 +156,24 @@ static void f2fs_unlock_rpages(struct compress_ctx *cc, int len)
 }
 
 static void f2fs_put_rpages_wbc(struct compress_ctx *cc,
-		struct writeback_control *wbc, bool redirty, int unlock)
+				struct writeback_control *wbc, bool redirty,
+				int unlock)
 {
-	unsigned int i;
-
-	for (i = 0; i < cc->cluster_size; i++) {
+	
+	unsigned int num_to_skip = 0;
+	for (int i = 0; i < cc->cluster_size; i++) {
+		struct folio *folio;
+		num_to_skip=1;
 		if (!cc->rpages[i])
 			continue;
-		if (redirty)
-			redirty_page_for_writepage(wbc, cc->rpages[i]);
-		f2fs_put_page(cc->rpages[i], unlock);
+		folio = page_folio(cc->rpages[i]);
+		if(redirty)
+			folio_redirty_for_writepage(wbc,folio);
+		f2fs_folio_put(folio,unlock);
+		while ((i + num_to_skip) < cc->cluster_size && cc->rpages[i + num_to_skip] &&
+		       page_folio(cc->rpages[i + num_to_skip]) == folio) {
+			num_to_skip++;
+		}
 	}
 }
 
@@ -846,11 +876,14 @@ bool f2fs_cluster_is_empty(struct compress_ctx *cc)
 	return cc->nr_rpages == 0;
 }
 
-static bool f2fs_cluster_is_full(struct compress_ctx *cc)
+bool f2fs_cluster_is_full(struct compress_ctx *cc)
 {
 	return cc->cluster_size == cc->nr_rpages;
 }
-
+bool f2fs_cluster_is_partial_full(struct compress_ctx *cc)
+{
+	return cc->nr_rpages>0&&cc->nr_rpages<cc->cluster_size;
+}
 bool f2fs_cluster_can_merge_page(struct compress_ctx *cc, pgoff_t index)
 {
 	if (f2fs_cluster_is_empty(cc))
@@ -974,7 +1007,6 @@ static int __f2fs_get_cluster_blocks(struct inode *inode,
 
 	return count;
 }
-
 static int __f2fs_cluster_blocks(struct inode *inode, unsigned int cluster_idx,
 				enum cluster_check_type type)
 {
@@ -1053,61 +1085,119 @@ static bool cluster_may_compress(struct compress_ctx *cc)
 		return false;
 	return !cluster_has_invalid_data(cc);
 }
-
+static void set_cluster_write_pending(struct compress_ctx *cc)
+{
+	f2fs_bug_on(F2FS_I_SB(cc->inode), !f2fs_cluster_is_full(cc));
+	struct folio *folio = NULL;
+	int num_to_skip = 0;
+	for (int i = 0; i < cc->cluster_size; i += num_to_skip) {
+		if (!cc->rpages[i]) {
+			num_to_skip = 1;
+			continue;
+		}
+		folio = page_folio(cc->rpages[i]);
+		num_to_skip = min_t(unsigned int,folio_nr_pages(folio) -folio_page_idx(folio, cc->rpages[i]),cc->cluster_size - i);
+		struct f2fs_iomap_folio_state* fifs= folio->private;	
+		if(folio_order(folio)>0&&fifs)
+		{
+			atomic_add(num_to_skip<<PAGE_SHIFT, &fifs->write_bytes_pending);
+		}
+	}
+}
 static void set_cluster_writeback(struct compress_ctx *cc)
 {
-	int i;
-
-	for (i = 0; i < cc->cluster_size; i++) {
-		if (cc->rpages[i])
-			set_page_writeback(cc->rpages[i]);
+	f2fs_bug_on(F2FS_I_SB(cc->inode), !f2fs_cluster_is_full(cc));
+	struct folio *folio = NULL;
+	int num_to_skip = 0;
+	for (int i = 0; i < cc->cluster_size; i += num_to_skip) {
+		if (!cc->rpages[i]) {
+			num_to_skip = 1;
+			continue;
+		}
+		folio = page_folio(cc->rpages[i]);
+		if (!folio_test_writeback(folio))
+			folio_start_writeback(folio);
+		num_to_skip = min_t(unsigned int,folio_nr_pages(folio) -
+					  folio_page_idx(folio, cc->rpages[i]),
+				  cc->cluster_size - i);
 	}
 }
 
-static void cancel_cluster_writeback(struct compress_ctx *cc,
-			struct compress_io_ctx *cic, int submitted)
+static void cancel_cluster_writeback(struct compress_ctx *cc,struct compress_io_ctx *cic, int submitted)
 {
-	int i;
-
 	/* Wait for submitted IOs. */
 	if (submitted > 1) {
 		f2fs_submit_merged_write(F2FS_I_SB(cc->inode), DATA);
 		while (atomic_read(&cic->pending_pages) !=
-					(cc->valid_nr_cpages - submitted + 1))
+		       (cc->valid_nr_cpages - submitted + 1))
 			f2fs_io_schedule_timeout(DEFAULT_IO_TIMEOUT);
 	}
-
-	/* Cancel writeback and stay locked. */
-	for (i = 0; i < cc->cluster_size; i++) {
+	int num_to_skip = 0;
+    for (int i = 0; i < cc->cluster_size; i += num_to_skip) {
+		if (!cc->rpages[i]) {
+			num_to_skip = 1;
+			continue;
+		}
+		struct folio* folio = page_folio(cc->rpages[i]);
 		if (i < submitted) {
 			inode_inc_dirty_pages(cc->inode);
-			lock_page(cc->rpages[i]);
+			folio_lock(folio);
 		}
-		clear_page_private_gcing(cc->rpages[i]);
-		if (folio_test_writeback(page_folio(cc->rpages[i])))
-			end_page_writeback(cc->rpages[i]);
+		num_to_skip = min_t(unsigned int,folio_nr_pages(folio) -
+					  folio_page_idx(folio, cc->rpages[i]),
+				  cc->cluster_size - i);
+		f2fs_clear_folio_private_gcing(folio);
+		struct f2fs_iomap_folio_state *fifs = f2fs_folio_get_private(folio);
+		if (fifs) {
+			atomic_set(f2fs_ifs_dirty_bytes_pending_ptr(fifs,folio),0);
+			if (atomic_sub_and_test(num_to_skip<< PAGE_SHIFT, &fifs->write_bytes_pending)) {
+
+				folio_end_writeback(folio);
+			}
+		} else {
+			if (folio_test_writeback(folio)) {
+				folio_end_writeback(folio);
+			}
+		}
+		
 	}
 }
 
 static void set_cluster_dirty(struct compress_ctx *cc)
 {
-	int i;
-
-	for (i = 0; i < cc->cluster_size; i++)
-		if (cc->rpages[i]) {
-			set_page_dirty(cc->rpages[i]);
-			set_page_private_gcing(cc->rpages[i]);
+	f2fs_bug_on(F2FS_I_SB(cc->inode), !f2fs_cluster_is_full(cc));
+	struct folio *folio = NULL;
+	int num_to_skip = 0;
+	for (int i = 0; i < cc->cluster_size; i += num_to_skip) {
+		if (!cc->rpages[i]) {
+			num_to_skip = 1;
+			continue;
 		}
+		folio = page_folio(cc->rpages[i]);
+		struct f2fs_iomap_folio_state *fifs = folio->private;
+		num_to_skip = min_t(unsigned int,folio_nr_pages(folio) -
+					  folio_page_idx(folio, cc->rpages[i]),
+				  cc->cluster_size - i);
+		if (fifs) {
+			iomap_set_range_dirty(
+				folio, folio_page_idx(folio, cc->rpages[i]),
+				num_to_skip);
+		} else {
+			WARN_ON_ONCE(folio_test_large(folio));
+			folio_mark_dirty(folio);
+		}
+	}
 }
-
+/*Now we can allocate larger order folio in f2fs_filemap_get_folio
+add fgp_flag to parameter so caller can use it to control folio alloc order*/
 static int prepare_compress_overwrite(struct compress_ctx *cc,
-		struct page **pagep, pgoff_t index, void **fsdata)
+		struct page **pagep, pgoff_t index, void **fsdata,fgf_t fgp_flag)
 {
 	struct f2fs_sb_info *sbi = F2FS_I_SB(cc->inode);
 	struct address_space *mapping = cc->inode->i_mapping;
 	struct folio *folio;
 	sector_t last_block_in_bio;
-	fgf_t fgp_flag = FGP_LOCK | FGP_WRITE | FGP_CREAT;
+	fgp_flag = FGP_LOCK | FGP_WRITE | FGP_CREAT;
 	pgoff_t start_idx = start_idx_of_cluster(cc);
 	int i, ret;
 
@@ -1119,27 +1209,44 @@ retry:
 	ret = f2fs_init_compress_ctx(cc);
 	if (ret)
 		return ret;
-
 	/* keep folio reference to avoid page reclaim */
-	for (i = 0; i < cc->cluster_size; i++) {
+	for (i = 0; i < cc->cluster_size; ) {
 		folio = f2fs_filemap_get_folio(mapping, start_idx + i,
 				fgp_flag, GFP_NOFS);
 		if (IS_ERR(folio)) {
 			ret = PTR_ERR(folio);
 			goto unlock_pages;
 		}
+		bool needs_read = false;
+		pgoff_t idx_in_folio=offset_in_folio(folio,(start_idx+i)<<PAGE_SHIFT)>>PAGE_SHIFT;
+		unsigned int num_pages_iter=min_t(unsigned int,folio_nr_pages(folio)-idx_in_folio,cc->cluster_size-i);
+		for (; idx_in_folio < num_pages_iter; ++idx_in_folio) {
 
-		if (folio_test_uptodate(folio))
-			f2fs_folio_put(folio, true);
+			struct f2fs_iomap_folio_state* fifs=folio->private;
+			if (folio_order(folio)>0&&fifs&&!f2fs_ifs_block_is_uptodate(fifs, idx_in_folio)) {
+				needs_read = true;
+				break;
+			}
+			else if(!folio_test_uptodate(folio)) {
+				needs_read = true;
+				break;
+			}
+
+		}
+		if(needs_read)
+		{
+			f2fs_compress_ctx_add_folio(cc,folio,(folio->index + idx_in_folio) << PAGE_SHIFT,(num_pages_iter-idx_in_folio)<<PAGE_SHIFT);
+		}
 		else
-			f2fs_compress_ctx_add_page(cc, folio);
+		{
+			folio_put(folio);
+		}
+		i+=num_pages_iter;
 	}
-
 	if (!f2fs_cluster_is_empty(cc)) {
 		struct bio *bio = NULL;
 
-		ret = f2fs_read_multi_pages(cc, &bio, cc->cluster_size,
-					&last_block_in_bio, NULL, true);
+		ret = f2fs_read_multi_folios(cc, &bio,NULL, true);
 		f2fs_put_rpages(cc);
 		f2fs_destroy_compress_ctx(cc, true);
 		if (ret)
@@ -1152,7 +1259,7 @@ retry:
 			goto out;
 	}
 
-	for (i = 0; i < cc->cluster_size; i++) {
+	for (i = 0; i < cc->cluster_size; ) {
 		f2fs_bug_on(sbi, cc->rpages[i]);
 
 		folio = filemap_lock_folio(mapping, start_idx + i);
@@ -1162,7 +1269,9 @@ retry:
 		}
 
 		f2fs_folio_wait_writeback(folio, DATA, true, true);
-		f2fs_compress_ctx_add_page(cc, folio);
+		pgoff_t idx_in_folio=offset_in_folio(folio,(start_idx+i)<<PAGE_SHIFT)>>PAGE_SHIFT;
+		unsigned int num_pages_to_add=min_t(unsigned int,folio_nr_pages(folio)-idx_in_folio,cc->cluster_size-i);
+		f2fs_compress_ctx_add_folio(cc, folio,(start_idx + i) >> PAGE_SHIFT,num_pages_to_add<<PAGE_SHIFT);
 
 		if (!folio_test_uptodate(folio)) {
 			f2fs_handle_page_eio(sbi, folio, DATA);
@@ -1172,6 +1281,7 @@ release_and_retry:
 			f2fs_destroy_compress_ctx(cc, true);
 			goto retry;
 		}
+		i+=num_pages_to_add;
 	}
 
 	if (likely(!ret)) {
@@ -1187,9 +1297,96 @@ unlock_pages:
 out:
 	return ret;
 }
+// static int prepare_compress_overwrite(struct compress_ctx *cc,
+// 				      struct page **pagep, pgoff_t index,
+// 				      void **fsdata)
+// {
+// 	struct f2fs_sb_info *sbi = F2FS_I_SB(cc->inode);
+// 	struct address_space *mapping = cc->inode->i_mapping;
+// 	struct folio *folio;
+// 	sector_t last_block_in_bio;
+// 	fgf_t fgp_flag = FGP_LOCK | FGP_WRITE | FGP_CREAT;
+// 	pgoff_t start_idx = start_idx_of_cluster(cc);
+// 	int i, ret;
 
-int f2fs_prepare_compress_overwrite(struct inode *inode,
-		struct page **pagep, pgoff_t index, void **fsdata)
+// retry:
+// 	ret = f2fs_is_compressed_cluster(cc->inode, start_idx);
+// 	if (ret <= 0)
+// 		return ret;
+
+// 	ret = f2fs_init_compress_ctx(cc);
+// 	if (ret)
+// 		return ret;
+
+// 	/* keep folio reference to avoid page reclaim */
+// 	for (i = 0; i < cc->cluster_size; i++) {
+// 		folio = f2fs_filemap_get_folio(mapping, start_idx + i, fgp_flag,
+// 					       GFP_NOFS);
+// 		if (IS_ERR(folio)) {
+// 			ret = PTR_ERR(folio);
+// 			goto unlock_pages;
+// 		}
+
+// 		if (folio_test_uptodate(folio))
+// 			f2fs_folio_put(folio, true);
+// 		else
+// 			f2fs_compress_ctx_add_page(cc, folio);
+// 	}
+
+// 	if (!f2fs_cluster_is_empty(cc)) {
+// 		struct bio *bio = NULL;
+
+// 		ret = f2fs_read_multi_pages(cc, &bio, cc->cluster_size,
+// 					    &last_block_in_bio, NULL, true);
+// 		f2fs_put_rpages(cc);
+// 		f2fs_destroy_compress_ctx(cc, true);
+// 		if (ret)
+// 			goto out;
+// 		if (bio)
+// 			f2fs_submit_read_bio(sbi, bio, DATA);
+
+// 		ret = f2fs_init_compress_ctx(cc);
+// 		if (ret)
+// 			goto out;
+// 	}
+
+// 	for (i = 0; i < cc->cluster_size; i++) {
+// 		f2fs_bug_on(sbi, cc->rpages[i]);
+
+// 		folio = filemap_lock_folio(mapping, start_idx + i);
+// 		if (IS_ERR(folio)) {
+// 			/* folio could be truncated */
+// 			goto release_and_retry;
+// 		}
+
+// 		f2fs_folio_wait_writeback(folio, DATA, true, true);
+// 		f2fs_compress_ctx_add_page(cc, folio);
+
+// 		if (!folio_test_uptodate(folio)) {
+// 			f2fs_handle_page_eio(sbi, folio, DATA);
+// release_and_retry:
+// 			f2fs_put_rpages(cc);
+// 			f2fs_unlock_rpages(cc, i + 1);
+// 			f2fs_destroy_compress_ctx(cc, true);
+// 			goto retry;
+// 		}
+// 	}
+
+// 	if (likely(!ret)) {
+// 		*fsdata = cc->rpages;
+// 		*pagep = cc->rpages[offset_in_cluster(cc, index)];
+// 		return cc->cluster_size;
+// 	}
+
+// unlock_pages:
+// 	f2fs_put_rpages(cc);
+// 	f2fs_unlock_rpages(cc, i);
+// 	f2fs_destroy_compress_ctx(cc, true);
+// out:
+// 	return ret;
+// }
+int f2fs_prepare_compress_overwrite(struct inode *inode, struct page **pagep,
+				    pgoff_t index, void **fsdata,fgf_t fgp_flag)
 {
 	struct compress_ctx cc = {
 		.inode = inode,
@@ -1200,7 +1397,7 @@ int f2fs_prepare_compress_overwrite(struct inode *inode,
 		.nr_rpages = 0,
 	};
 
-	return prepare_compress_overwrite(&cc, pagep, index, fsdata);
+	return prepare_compress_overwrite(&cc, pagep, index, fsdata,fgp_flag);
 }
 
 bool f2fs_compress_write_end(struct inode *inode, void *fsdata,
@@ -1230,8 +1427,8 @@ int f2fs_truncate_partial_cluster(struct inode *inode, u64 from, bool lock)
 	void *fsdata = NULL;
 	struct page *pagep;
 	int log_cluster_size = F2FS_I(inode)->i_log_cluster_size;
-	pgoff_t start_idx = from >> (PAGE_SHIFT + log_cluster_size) <<
-							log_cluster_size;
+	pgoff_t start_idx = from >> (PAGE_SHIFT + log_cluster_size)
+					    << log_cluster_size;
 	int err;
 
 	err = f2fs_is_compressed_cluster(inode, start_idx);
@@ -1244,7 +1441,7 @@ int f2fs_truncate_partial_cluster(struct inode *inode, u64 from, bool lock)
 
 	/* truncate compressed cluster */
 	err = f2fs_prepare_compress_overwrite(inode, &pagep,
-						start_idx, &fsdata);
+						start_idx, &fsdata,0);
 
 	/* should not be a normal cluster */
 	f2fs_bug_on(F2FS_I_SB(inode), err == 0);
@@ -1295,8 +1492,7 @@ static int f2fs_write_compressed_pages(struct compress_ctx *cc,
 		.compressed_page = NULL,
 		.io_type = io_type,
 		.io_wbc = wbc,
-		.encrypted = fscrypt_inode_uses_fs_layer_crypto(cc->inode) ?
-									1 : 0,
+		.encrypted = fscrypt_inode_uses_fs_layer_crypto(cc->inode) ? 1 :0,
 	};
 	struct folio *folio;
 	struct dnode_of_data dn;
@@ -1378,12 +1574,11 @@ static int f2fs_write_compressed_pages(struct compress_ctx *cc,
 			cc->cpages[i] = fio.encrypted_page;
 		}
 	}
-
+	
 	set_cluster_writeback(cc);
-
+	set_cluster_write_pending(cc);
 	for (i = 0; i < cc->cluster_size; i++)
 		cic->rpages[i] = cc->rpages[i];
-
 	for (i = 0; i < cc->cluster_size; i++, dn.ofs_in_node++) {
 		block_t blkaddr;
 
@@ -1433,7 +1628,21 @@ static int f2fs_write_compressed_pages(struct compress_ctx *cc,
 		(*submitted)++;
 unlock_continue:
 		inode_dec_dirty_pages(cc->inode);
-		unlock_page(fio.page);
+		folio = page_folio(fio.page);
+		struct f2fs_iomap_folio_state *fifs = folio->private;
+		if(folio_order(folio)>0&&fifs)
+		{
+			if(atomic_sub_and_test(PAGE_SIZE,f2fs_ifs_dirty_bytes_pending_ptr(fifs,folio))
+			&&f2fs_folio_private_deferred_unlock(folio))
+			{	
+				f2fs_err(F2FS_I_SB(cc->inode),"folio index %d order%dunlock",folio->index,folio_order(folio));
+				f2fs_clear_folio_private_deferred_unlock(folio);
+				folio_unlock(folio);
+			}
+		}
+		else{
+			folio_unlock(folio);
+		}
 	}
 
 	if (fio.compr_blocks)
@@ -1493,33 +1702,47 @@ void f2fs_compress_write_end_io(struct bio *bio, struct page *page)
 	struct compress_io_ctx *cic =
 			(struct compress_io_ctx *)page_private(page);
 	enum count_type type = WB_DATA_TYPE(page,
-				f2fs_is_compressed_page(page));
+				f2fs_is_compressed_folio(page_folio(page)));
 	int i;
 
 	if (unlikely(bio->bi_status))
 		mapping_set_error(cic->inode->i_mapping, -EIO);
 
 	f2fs_compress_free_page(page);
-
 	dec_page_count(sbi, type);
 
 	if (atomic_dec_return(&cic->pending_pages))
+	{
 		return;
-
-	for (i = 0; i < cic->nr_rpages; i++) {
-		WARN_ON(!cic->rpages[i]);
-		clear_page_private_gcing(cic->rpages[i]);
-		end_page_writeback(cic->rpages[i]);
 	}
-
+	unsigned int num_to_skip = 0;
+	for (i = 0; i < cic->nr_rpages; i += num_to_skip) {
+		if (!cic->rpages[i]) {
+			WARN_ON(!cic->rpages[i]);
+			num_to_skip = 1;
+			continue;
+		}
+		struct folio *folio = page_folio(cic->rpages[i]);
+		struct f2fs_iomap_folio_state *fifs = folio->private;
+		f2fs_clear_folio_private_gcing(folio);
+		num_to_skip = min_t(unsigned int,folio_nr_pages(folio) -folio_page_idx(folio, cic->rpages[i]),cic->nr_rpages - i);
+		if (folio_order(folio)>0&&fifs) {
+			if (atomic_sub_and_test(num_to_skip << PAGE_SHIFT,&fifs->write_bytes_pending))
+			{
+				folio_end_writeback(folio);
+			}
+		}
+		else
+		{
+			folio_end_writeback(folio);
+		}
+	}
 	page_array_free(cic->inode, cic->rpages, cic->nr_rpages);
 	kmem_cache_free(cic_entry_slab, cic);
 }
-
-static int f2fs_write_raw_pages(struct compress_ctx *cc,
-					int *submitted_p,
-					struct writeback_control *wbc,
-					enum iostat_type io_type)
+static int f2fs_write_raw_pages(struct compress_ctx *cc, int *submitted_p,
+				struct writeback_control *wbc,
+				enum iostat_type io_type)
 {
 	struct address_space *mapping = cc->inode->i_mapping;
 	struct f2fs_sb_info *sbi = F2FS_M_SB(mapping);
@@ -1527,79 +1750,90 @@ static int f2fs_write_raw_pages(struct compress_ctx *cc,
 	int ret = 0;
 
 	compr_blocks = f2fs_compressed_blocks(cc);
-
-	for (i = 0; i < cc->cluster_size; i++) {
-		if (!cc->rpages[i])
+	unsigned int num_to_skip = 0;
+	// unsigned int *origin_folio_orders=kmalloc(sizeof(unsigned int)*cc->cluster_size, GFP_NOFS);
+	// if(!origin_folio_orders)
+		// return -ENOMEM;
+	for (i = 0; i < cc->cluster_size; i += num_to_skip) {
+		num_to_skip = 1;
+		if (!cc->rpages[i]) {
 			continue;
-
-		redirty_page_for_writepage(wbc, cc->rpages[i]);
-		unlock_page(cc->rpages[i]);
+		}
+		struct folio *folio = page_folio(cc->rpages[i]);
+		folio_redirty_for_writepage(wbc, folio);
+		
+		/*f2fs_write_raw_pages can have discontinuous cluster,
+		we must count all page that belongs to the same folio to skip here*/
+		while ((i + num_to_skip) < cc->cluster_size && cc->rpages[i + num_to_skip] &&
+		       page_folio(cc->rpages[i + num_to_skip]) == folio) {
+			num_to_skip++;
+		}
 	}
-
 	if (compr_blocks < 0)
+	{
 		return compr_blocks;
-
+	}
 	/* overwrite compressed cluster w/ normal cluster */
 	if (compr_blocks > 0)
 		f2fs_lock_op(sbi);
 
-	for (i = 0; i < cc->cluster_size; i++) {
+	for (i = 0; i < cc->cluster_size; i+=num_to_skip) {
 		struct folio *folio;
-
+		num_to_skip = 1;
 		if (!cc->rpages[i])
 			continue;
 		folio = page_folio(cc->rpages[i]);
-retry_write:
-		folio_lock(folio);
-
-		if (folio->mapping != mapping) {
-continue_unlock:
-			folio_unlock(folio);
-			continue;
+		while ((i + num_to_skip) < cc->cluster_size && cc->rpages[i + num_to_skip] &&
+		       page_folio(cc->rpages[i + num_to_skip]) == folio) {
+			num_to_skip++;
 		}
-
-		if (!folio_test_dirty(folio))
-			goto continue_unlock;
-
-		if (folio_test_writeback(folio)) {
-			if (wbc->sync_mode == WB_SYNC_NONE)
-				goto continue_unlock;
-			f2fs_folio_wait_writeback(folio, DATA, true, true);
-		}
-
-		if (!folio_clear_dirty_for_io(folio))
-			goto continue_unlock;
-
+		loff_t start =(folio->index+folio_page_idx(folio,cc->rpages[i]))<<PAGE_SHIFT;
+		loff_t end =
+			(folio->index+folio_page_idx(folio, cc->rpages[i]) + num_to_skip)
+			<< PAGE_SHIFT;
 		submitted = 0;
-		ret = f2fs_write_single_data_page(folio, &submitted,
-						NULL, NULL, wbc, io_type,
-						compr_blocks, false);
+		ret = f2fs_write_single_data_folio(folio, &submitted, NULL,
+						   NULL, wbc, io_type,
+						   compr_blocks, true, false,start,
+						   end);
+		struct f2fs_iomap_folio_state *fifs = folio->private;
 		if (ret) {
-			if (ret == AOP_WRITEPAGE_ACTIVATE) {
-				folio_unlock(folio);
-				ret = 0;
-			} else if (ret == -EAGAIN) {
-				ret = 0;
-				/*
-				 * for quota file, just redirty left pages to
-				 * avoid deadlock caused by cluster update race
-				 * from foreground operation.
-				 */
-				if (IS_NOQUOTA(cc->inode))
-					goto out;
-				f2fs_io_schedule_timeout(DEFAULT_IO_TIMEOUT);
-				goto retry_write;
-			}
+			/*TODO: 暂时不知道怎么处理AOP_WRITEPAGE_ACTIVATE
+			因为 Matthew先生计划移除文件系统的
+			writepage,这样未来pageout将不会再进行脏页写回了*/
+			// if (ret == AOP_WRITEPAGE_ACTIVATE) {
+				// folio_unlock(folio);
+				// ret = 0;
+			// } else if (ret == -EAGAIN) {
+			// 	ret = 0;
+			// 	/*
+			// 	 * for quota file, just redirty left pages to
+			// 	 * avoid deadlock caused by cluster update race
+			// 	 * from foreground operation.
+			// 	 */
+			// 	if (IS_NOQUOTA(cc->inode))
+			// 		goto out;
+			// 	f2fs_io_schedule_timeout(DEFAULT_IO_TIMEOUT);
+			// 	goto retry_write;
+			// }
+			if(folio_order(folio)>0&&fifs)
+				atomic_set(f2fs_ifs_dirty_bytes_pending_ptr(fifs,folio),0);
 			goto out;
 		}
-
+		if(folio_order(folio)>0&&fifs){
+			if(atomic_sub_and_test(submitted<<PAGE_SHIFT,f2fs_ifs_dirty_bytes_pending_ptr(fifs,folio))&&f2fs_folio_private_deferred_unlock(folio))
+			{
+				f2fs_clear_folio_private_deferred_unlock(folio);
+				folio_unlock(folio);
+			}
+		}
 		*submitted_p += submitted;
 	}
 
 out:
 	if (compr_blocks > 0)
 		f2fs_unlock_op(sbi);
-
+	// kfree(origin_folio_orders);
 	f2fs_balance_fs(sbi, true);
 	return ret;
 }
@@ -1610,7 +1844,6 @@ int f2fs_write_multi_pages(struct compress_ctx *cc,
 					enum iostat_type io_type)
 {
 	int err;
-
 	*submitted = 0;
 	if (cluster_may_compress(cc)) {
 		err = f2fs_compress_pages(cc);
@@ -1858,19 +2091,49 @@ void f2fs_decompress_end_io(struct decompress_io_ctx *dic, bool failed,
 	}
 
 	/* Update and unlock the cluster's pagecache pages. */
-	for (i = 0; i < dic->cluster_size; i++) {
-		struct page *rpage = dic->rpages[i];
+	// for (i = 0; i < dic->cluster_size; i++) {
+	// 	struct page *rpage = dic->rpages[i];
 
-		if (!rpage)
+	// 	if (!rpage)
+	// 		continue;
+
+	// 	if (failed)
+	// 		ClearPageUptodate(rpage);
+	// 	else
+	// 		SetPageUptodate(rpage);
+	// 	unlock_page(rpage); 
+	// }
+	int num_to_skip=0;
+	for (int i = 0; i < dic->cluster_size; i+=num_to_skip) {
+		struct folio *folio;
+		num_to_skip=1;
+		if (!dic->rpages[i])
 			continue;
-
-		if (failed)
-			ClearPageUptodate(rpage);
+		folio = page_folio(dic->rpages[i]);	
+		while ((i + num_to_skip) < dic->cluster_size && dic->rpages[i + num_to_skip] &&
+		       page_folio(dic->rpages[i + num_to_skip]) == folio) {
+			num_to_skip++;
+		}
+		struct f2fs_iomap_folio_state *fifs=folio->private;
+		if(failed)
+		{
+			if(folio_order(folio)>0&&fifs)
+			{
+				f2fs_ifs_clear_range_uptodate(folio,fifs,0,num_to_skip<<PAGE_SHIFT);
+				folio_clear_uptodate(folio);
+				folio_unlock(folio);
+			}
+			else
+			{
+				folio_clear_uptodate(folio);
+				folio_unlock(folio);
+			}
+		}
 		else
-			SetPageUptodate(rpage);
-		unlock_page(rpage);
+		{	
+			f2fs_iomap_finish_folio_read(folio,0,num_to_skip<<PAGE_SHIFT,0);
+		}
 	}
-
 	/*
 	 * Release the reference to the decompress_io_ctx that was being held
 	 * for I/O completion.
@@ -1928,15 +2191,16 @@ struct address_space *COMPRESS_MAPPING(struct f2fs_sb_info *sbi)
 }
 
 void f2fs_invalidate_compress_pages_range(struct f2fs_sb_info *sbi,
-				block_t blkaddr, unsigned int len)
+					  block_t blkaddr, unsigned int len)
 {
 	if (!sbi->compress_inode)
 		return;
-	invalidate_mapping_pages(COMPRESS_MAPPING(sbi), blkaddr, blkaddr + len - 1);
+	invalidate_mapping_pages(COMPRESS_MAPPING(sbi), blkaddr,
+				 blkaddr + len - 1);
 }
 
 void f2fs_cache_compressed_page(struct f2fs_sb_info *sbi, struct page *page,
-						nid_t ino, block_t blkaddr)
+				nid_t ino, block_t blkaddr)
 {
 	struct folio *cfolio;
 	int ret;
@@ -2110,4 +2374,52 @@ void f2fs_destroy_compress_cache(void)
 {
 	kmem_cache_destroy(dic_entry_slab);
 	kmem_cache_destroy(cic_entry_slab);
+}
+/*Add part of folio into compress_ctx*/
+void f2fs_compress_ctx_add_folio(struct compress_ctx *cc, struct folio *folio,
+				 loff_t pos, loff_t rlen)
+{	
+	unsigned int cluster_ofs;
+	loff_t poff = offset_in_folio(folio, pos);
+	unsigned int idx_in_folio = poff >> PAGE_SHIFT;
+	if (!f2fs_cluster_can_merge_page(cc, folio->index+idx_in_folio))
+		f2fs_bug_on(F2FS_I_SB(cc->inode), 1);
+	cluster_ofs = offset_in_cluster(cc, folio->index+idx_in_folio);
+	int num_pages_to_add =
+		min_t(unsigned int,(unsigned int)folio_nr_pages(folio) - idx_in_folio,
+		    cc->cluster_size - cc->nr_rpages);
+	num_pages_to_add = min_t(unsigned int,num_pages_to_add, rlen >> PAGE_SHIFT);
+	for (int i = 0; i < num_pages_to_add; ++i) {
+		cc->rpages[cluster_ofs] = folio_page(folio, idx_in_folio + i);
+		cc->nr_rpages++;
+		cluster_ofs++;
+	}
+	cc->cluster_idx = cluster_idx(cc, folio->index+idx_in_folio);
+}
+int f2fs_wait_cluster_uptodate(struct inode*inode,pgoff_t start_check_idx,unsigned int cluster_size)
+{
+	int ret =0 ;
+	bool all_uptodate = false;
+	pgoff_t end_idx_of_cluster = i_end_idx_of_cluster(inode,start_check_idx);
+	while (!all_uptodate) {
+	all_uptodate = true;
+
+	    for (pgoff_t idx = start_check_idx; idx < end_idx_of_cluster; idx++) {
+	        struct folio *check_folio = f2fs_filemap_get_folio(inode->i_mapping, idx, FGP_WRITEBEGIN,GFP_NOFS); // 查找并锁定
+	        if (IS_ERR(check_folio)) 
+				return ERR_PTR(check_folio);
+	        if (!folio_test_uptodate(check_folio)) {
+			all_uptodate = false;
+
+	            folio_unlock(check_folio);
+	            folio_put(check_folio);
+	            break; 
+	        }
+	        folio_unlock(check_folio);
+	        folio_put(check_folio);
+	    }
+	    if (!all_uptodate)
+	        cond_resched(); 
+	}
+	return ret;
 }

--- a/fs/f2fs/compress.c
+++ b/fs/f2fs/compress.c
@@ -14,12 +14,12 @@
 #include <linux/lz4.h>
 #include <linux/zstd.h>
 #include <linux/pagevec.h>
-
+#include <linux/f2fs_fs.h>
 #include "f2fs.h"
 #include "node.h"
 #include "segment.h"
 #include <trace/events/f2fs.h>
-
+#include "f2fs_ifs.h"
 static struct kmem_cache *cic_entry_slab;
 static struct kmem_cache *dic_entry_slab;
 
@@ -86,7 +86,17 @@ bool f2fs_is_compressed_page(struct page *page)
 		*((u32 *)page_private(page)) != F2FS_COMPRESSED_PAGE_MAGIC);
 	return true;
 }
-
+bool f2fs_is_compressed_folio(struct folio *folio)
+{ 
+	if(!folio_test_private(folio))
+		return false;
+	if(f2fs_folio_private_nonpointer(folio))
+		return false;
+	if(folio_order(folio)>0) /*compressed folio cunrrent don't support higer order*/
+		return false;	
+	f2fs_bug_on(F2FS_P_SB(&folio->page),*((u32*)folio->private)!= F2FS_COMPRESSED_PAGE_MAGIC);
+	return true;
+}
 static void f2fs_set_compressed_page(struct page *page,
 		struct inode *inode, pgoff_t index, void *data)
 {

--- a/fs/f2fs/data.c
+++ b/fs/f2fs/data.c
@@ -30,19 +30,19 @@
 #include "f2fs_ifs.h"
 #include <trace/events/f2fs.h>
 
-#define NUM_PREALLOC_POST_READ_CTXS	128
+#define NUM_PREALLOC_POST_READ_CTXS 128
 
 static struct kmem_cache *bio_post_read_ctx_cache;
 static struct kmem_cache *bio_entry_slab;
 static mempool_t *bio_post_read_ctx_pool;
 static struct bio_set f2fs_bioset;
 
-#define	F2FS_BIO_POOL_SIZE	NR_CURSEG_TYPE
+#define F2FS_BIO_POOL_SIZE NR_CURSEG_TYPE
 
 int __init f2fs_init_bioset(void)
 {
-	return bioset_init(&f2fs_bioset, F2FS_BIO_POOL_SIZE,
-					0, BIOSET_NEED_BVECS);
+	return bioset_init(&f2fs_bioset, F2FS_BIO_POOL_SIZE, 0,
+			   BIOSET_NEED_BVECS);
 }
 
 void f2fs_destroy_bioset(void)
@@ -93,19 +93,19 @@ static enum count_type __read_io_type(struct folio *folio)
 /* postprocessing steps for read bios */
 enum bio_post_read_step {
 #ifdef CONFIG_FS_ENCRYPTION
-	STEP_DECRYPT	= BIT(0),
+	STEP_DECRYPT = BIT(0),
 #else
-	STEP_DECRYPT	= 0,	/* compile out the decryption-related code */
+	STEP_DECRYPT = 0, /* compile out the decryption-related code */
 #endif
 #ifdef CONFIG_F2FS_FS_COMPRESSION
-	STEP_DECOMPRESS	= BIT(1),
+	STEP_DECOMPRESS = BIT(1),
 #else
-	STEP_DECOMPRESS	= 0,	/* compile out the decompression-related code */
+	STEP_DECOMPRESS = 0, /* compile out the decompression-related code */
 #endif
 #ifdef CONFIG_FS_VERITY
-	STEP_VERITY	= BIT(2),
+	STEP_VERITY = BIT(2),
 #else
-	STEP_VERITY	= 0,	/* compile out the verity-related code */
+	STEP_VERITY = 0, /* compile out the verity-related code */
 #endif
 };
 
@@ -154,14 +154,41 @@ static void f2fs_finish_read_bio(struct bio *bio, bool in_task)
 		}
 
 		dec_page_count(F2FS_F_SB(folio), __read_io_type(folio));
-		folio_end_read(folio, bio->bi_status == 0);
+		int error=!(bio->bi_status == 0);
+		f2fs_iomap_finish_folio_read(folio,fi.offset,
+		fi.length,error);
 	}
 
 	if (ctx)
 		mempool_free(ctx, bio_post_read_ctx_pool);
 	bio_put(bio);
 }
-
+void f2fs_iomap_finish_folio_read(struct folio *folio, size_t off,size_t len, int error)
+{
+	struct f2fs_iomap_folio_state *fifs =folio->private;
+		bool uptodate = !error;
+		bool finished = true;
+		if(folio_order(folio)>0&&fifs)
+		{
+			unsigned long flags;
+			spin_lock_irqsave(&fifs->state_lock, flags);
+			fifs->read_bytes_pending-=len;
+			if(!error)
+			{	
+				uptodate=ifs_set_range_uptodate(folio, (struct iomap_folio_state*)fifs,off,len);
+			}
+			finished = (fifs->read_bytes_pending == 0||fifs->read_bytes_pending==F2FS_IFS_MAGIC);
+			spin_unlock_irqrestore(&fifs->state_lock, flags);
+			if(finished)
+			{
+				folio_end_read(folio, uptodate);
+			}
+		}
+		else
+		{
+			folio_end_read(folio, !error);
+		}
+}
 static void f2fs_verify_bio(struct work_struct *work)
 {
 	struct bio_post_read_ctx *ctx =
@@ -333,7 +360,6 @@ static void f2fs_write_end_io(struct bio *bio)
 	bio_for_each_folio_all(fi, bio) {
 		struct folio *folio = fi.folio;
 		enum count_type type;
-
 		if (fscrypt_is_bounce_folio(folio)) {
 			struct folio *io_folio = folio;
 
@@ -354,20 +380,30 @@ static void f2fs_write_end_io(struct bio *bio)
 			mapping_set_error(folio->mapping, -EIO);
 			if (type == F2FS_WB_CP_DATA)
 				f2fs_stop_checkpoint(sbi, true,
-						STOP_CP_REASON_WRITE_FAIL);
+						     STOP_CP_REASON_WRITE_FAIL);
 		}
 
-		f2fs_bug_on(sbi, folio->mapping == NODE_MAPPING(sbi) &&
-				folio->index != nid_of_node(&folio->page));
+		f2fs_bug_on(sbi,
+			    folio->mapping == NODE_MAPPING(sbi) &&
+				    folio->index != nid_of_node(&folio->page));
 
 		dec_page_count(sbi, type);
 		if (f2fs_in_warm_node_list(sbi, folio))
 			f2fs_del_fsync_node_entry(sbi, folio);
-		clear_page_private_gcing(&folio->page);
-		folio_end_writeback(folio);
+		f2fs_clear_folio_private_gcing(folio);
+		struct f2fs_iomap_folio_state *fifs = folio->private;
+		if (folio_order(folio)>0&&fifs) {
+			// fi.length is the number of bytes from this folio in this bio segment
+			f2fs_bug_on(F2FS_F_SB(folio),atomic_read(&fifs->write_bytes_pending) <=0);
+			if (atomic_sub_and_test(fi.length,
+						&fifs->write_bytes_pending)) {
+				folio_end_writeback(folio);
+			}
+		} else {
+			folio_end_writeback(folio);
+		}
 	}
-	if (!get_pages(sbi, F2FS_WB_CP_DATA) &&
-				wq_has_sleeper(&sbi->cp_wait))
+	if (!get_pages(sbi, F2FS_WB_CP_DATA) && wq_has_sleeper(&sbi->cp_wait))
 		wake_up(&sbi->cp_wait);
 
 	bio_put(bio);
@@ -521,7 +557,39 @@ void f2fs_submit_read_bio(struct f2fs_sb_info *sbi, struct bio *bio,
 	iostat_update_submit_ctx(bio, type);
 	submit_bio(bio);
 }
+int f2fs_submit_read_bio_sync(struct bio *bio)
+{
+	int ret;
 
+	// 1. 同步提交 I/O
+	ret = submit_bio_wait(bio);
+	if (ret) {
+		bio_put(bio);
+		return ret;
+	}
+
+	// 2. 执行后处理
+	struct bio_post_read_ctx *ctx = bio->bi_private;
+	if (ctx) {
+		// 直接调用 f2fs_post_read_work 的核心逻辑，但不需要 work_struct
+		if ((ctx->enabled_steps & STEP_DECRYPT) && !fscrypt_decrypt_bio(bio)) {
+			// 解密失败
+			f2fs_finish_read_bio(bio, true); // true for in_task
+			return -EIO;
+		}
+
+		if (ctx->enabled_steps & STEP_DECOMPRESS)
+			f2fs_handle_step_decompress(ctx, true); // true for in_task
+
+		// f2fs_verify_and_finish_bio 会处理 bio_put 和其他清理工作
+		f2fs_verify_and_finish_bio(bio, true);
+	} else {
+		// 如果没有 ctx，也要确保 bio 被释放
+		bio_put(bio);
+	}
+
+	return 0; // 成功
+}
 static void f2fs_submit_write_bio(struct f2fs_sb_info *sbi, struct bio *bio,
 				  enum page_type type)
 {
@@ -697,7 +765,6 @@ int f2fs_submit_page_bio(struct f2fs_io_info *fio)
 	struct folio *fio_folio = page_folio(fio->page);
 	struct folio *data_folio = fio->encrypted_page ?
 			page_folio(fio->encrypted_page) : fio_folio;
-
 	if (!f2fs_is_valid_blkaddr(fio->sbi, fio->new_blkaddr,
 			fio->is_por ? META_POR : (__is_meta_io(fio) ?
 			META_GENERIC : DATA_GENERIC_ENHANCE)))
@@ -722,6 +789,7 @@ int f2fs_submit_page_bio(struct f2fs_io_info *fio)
 		f2fs_submit_read_bio(fio->sbi, bio, fio->type);
 	else
 		f2fs_submit_write_bio(fio->sbi, bio, fio->type);
+	fio->submitted = true;
 	return 0;
 }
 
@@ -737,7 +805,7 @@ static bool page_is_mergeable(struct f2fs_sb_info *sbi, struct bio *bio,
 }
 
 static bool io_type_is_mergeable(struct f2fs_bio_info *io,
-						struct f2fs_io_info *fio)
+				 struct f2fs_io_info *fio)
 {
 	if (io->fio.op != fio->op)
 		return false;
@@ -898,7 +966,6 @@ int f2fs_merge_page_bio(struct f2fs_io_info *fio)
 		return -EFSCORRUPTED;
 
 	trace_f2fs_submit_folio_bio(page_folio(page), fio);
-
 	if (bio && !page_is_mergeable(fio->sbi, bio, *fio->last_block,
 						fio->new_blkaddr))
 		f2fs_submit_merged_ipu_write(fio->sbi, &bio, NULL);
@@ -941,9 +1008,8 @@ static bool is_end_zone_blkaddr(struct f2fs_sb_info *sbi, block_t blkaddr)
 		blkaddr -= FDEV(devi).start_blk;
 		bdev = FDEV(devi).bdev;
 	}
-	return bdev_is_zoned(bdev) &&
-		f2fs_blkz_is_seq(sbi, devi, blkaddr) &&
-		(blkaddr % sbi->blocks_per_blkz == sbi->blocks_per_blkz - 1);
+	return bdev_is_zoned(bdev) && f2fs_blkz_is_seq(sbi, devi, blkaddr) &&
+	       (blkaddr % sbi->blocks_per_blkz == sbi->blocks_per_blkz - 1);
 }
 #endif
 
@@ -989,19 +1055,19 @@ next:
 		bio_page = fio->compressed_page;
 	else
 		bio_page = fio->page;
-
 	/* set submitted = true as a return value */
 	fio->submitted = 1;
 
 	type = WB_DATA_TYPE(bio_page, fio->compressed_page);
 	inc_page_count(sbi, type);
-
 	if (io->bio &&
 	    (!io_is_mergeable(sbi, io->bio, io, fio, io->last_block_in_bio,
 			      fio->new_blkaddr) ||
-	     !f2fs_crypt_mergeable_bio(io->bio, fio_inode(fio),
-				page_folio(bio_page)->index, fio)))
-		__submit_merged_bio(io);
+	     !f2fs_crypt_mergeable_bio(io->bio, inode,
+				       page_folio(bio_page)->index, fio)))
+		{ 
+			__submit_merged_bio(io);
+		}
 alloc_new:
 	if (io->bio == NULL) {
 		io->bio = __bio_alloc(fio, BIO_MAX_VECS);
@@ -1014,7 +1080,6 @@ alloc_new:
 		__submit_merged_bio(io);
 		goto alloc_new;
 	}
-
 	if (fio->io_wbc)
 		wbc_account_cgroup_owner(fio->io_wbc, page_folio(fio->page),
 					 PAGE_SIZE);
@@ -1394,7 +1459,6 @@ got_it:
 		f2fs_i_size_write(inode, ((loff_t)(index + 1) << PAGE_SHIFT));
 	return folio;
 }
-
 static int __allocate_data_block(struct dnode_of_data *dn, int seg_type)
 {
 	struct f2fs_sb_info *sbi = F2FS_I_SB(dn->inode);
@@ -1546,15 +1610,19 @@ static bool map_is_mergeable(struct f2fs_sb_info *sbi,
  * maps continuous logical blocks to physical blocks, and return such
  * info via f2fs_map_blocks structure.
  */
+// 
 int f2fs_map_blocks(struct inode *inode, struct f2fs_map_blocks *map, int flag)
 {
 	unsigned int maxblocks = map->m_len;
 	struct dnode_of_data dn;
 	struct f2fs_sb_info *sbi = F2FS_I_SB(inode);
-	int mode = map->m_may_create ? ALLOC_NODE : LOOKUP_NODE;
+	int mode = map->m_may_create ?
+			   ALLOC_NODE :
+			   LOOKUP_NODE; 
 	pgoff_t pgofs, end_offset, end;
 	int err = 0, ofs = 1;
-	unsigned int ofs_in_node, last_ofs_in_node;
+	unsigned int ofs_in_node,
+		last_ofs_in_node; 
 	blkcnt_t prealloc;
 	block_t blkaddr;
 	unsigned int start_pgofs;
@@ -1571,19 +1639,19 @@ int f2fs_map_blocks(struct inode *inode, struct f2fs_map_blocks *map, int flag)
 	map->m_multidev_dio =
 		f2fs_allow_multi_device_dio(F2FS_I_SB(inode), flag);
 
-	map->m_len = 0;
-	map->m_flags = 0;
+	map->m_len =
+		0; 
+	map->m_flags = 0; 
 
 	/* it only supports block size == page size */
-	pgofs =	(pgoff_t)map->m_lblk;
+	pgofs = (pgoff_t)map->m_lblk; 
 	end = pgofs + maxblocks;
-
 next_dnode:
 	if (map->m_may_create)
 		f2fs_map_lock(sbi, flag);
 
 	/* When reading holes, we need its node page */
-	set_new_dnode(&dn, inode, NULL, NULL, 0);
+	set_new_dnode(&dn, inode, NULL, NULL, 0); /*先拿到node页*/
 	err = f2fs_get_dnode_of_data(&dn, pgofs, mode);
 	if (err) {
 		if (flag == F2FS_GET_BLOCK_BMAP)
@@ -1593,21 +1661,25 @@ next_dnode:
 		goto unlock_out;
 	}
 
-	start_pgofs = pgofs;
+	start_pgofs = pgofs; /*start_pgofs是循环的初始计数器*/
 	prealloc = 0;
 	last_ofs_in_node = ofs_in_node = dn.ofs_in_node;
 	end_offset = ADDRS_PER_PAGE(&dn.node_folio->page, inode);
+	/*循环开始*/
+	// next_block:
 	do {
-		blkaddr = f2fs_data_blkaddr(&dn);
+		blkaddr = f2fs_data_blkaddr(&dn); /*然后拿到数据块地址*/
 		is_hole = !__is_valid_data_blkaddr(
-			blkaddr);
+			blkaddr); /*空洞这里记录的是数据块有效的取反*/
 		if (!is_hole && !f2fs_is_valid_blkaddr(sbi, blkaddr,
 						       DATA_GENERIC_ENHANCE)) {
-			err = -EFSCORRUPTED;
+			err = -EFSCORRUPTED; /*既不是空洞 又不是有效块
+		那肯定是出现文件系统污染了*/
 			goto sync_out;
 		}
 
 		/* use out-place-update for direct IO under LFS mode */
+		/*direct io 新地更新逻辑开始*/
 		if (map->m_may_create &&
 		    (is_hole ||
 		     (flag == F2FS_GET_BLOCK_DIO && f2fs_lfs_mode(sbi) &&
@@ -1617,7 +1689,7 @@ next_dnode:
 				goto sync_out;
 			}
 
-			switch (flag) {
+			switch (flag) { /*能写switch意味着它们都是互斥的*/
 			case F2FS_GET_BLOCK_PRE_AIO:
 				if (blkaddr == NULL_ADDR) {
 					prealloc++;
@@ -1634,7 +1706,7 @@ next_dnode:
 					file_need_truncate(inode);
 				set_inode_flag(inode, FI_APPEND_WRITE);
 				break;
-			default:
+			default: /*read_single_page走的就是default分支 显然在需要创建块逻辑的地方是错误的*/
 				WARN_ON_ONCE(1);
 				err = -EIO;
 				goto sync_out;
@@ -1643,7 +1715,7 @@ next_dnode:
 			blkaddr = dn.data_blkaddr;
 			if (is_hole)
 				map->m_flags |= F2FS_MAP_NEW;
-		} else if (is_hole) {
+		} else if (is_hole) { /*不创建新块但是是空洞*/
 			if (f2fs_compressed_file(inode) &&
 			    f2fs_sanity_check_cluster(&dn)) {
 				err = -EFSCORRUPTED;
@@ -1652,7 +1724,7 @@ next_dnode:
 			}
 
 			switch (flag) {
-			case F2FS_GET_BLOCK_PRECACHE:
+			case F2FS_GET_BLOCK_PRECACHE: /*在碰到文件空洞的情况下 直接跳出循环*/
 				goto sync_out;
 			case F2FS_GET_BLOCK_BMAP:
 				map->m_pblk = 0;
@@ -1665,11 +1737,11 @@ next_dnode:
 				}
 				break;
 			case F2FS_GET_BLOCK_DIO:
-				if (map->m_next_pgofs)
+				if (map->m_next_pgofs) /*还没设置f2fs_block_map中的next_pgofs的话 将其设置为+1*/
 					*map->m_next_pgofs = pgofs + 1;
 				break;
 			case F2FS_GET_BLOCK_IOMAP:
-				if (map->m_next_pgofs)
+				if (map->m_next_pgofs) /*还没设置f2fs_block_map中的next_pgofs的话 将其设置为+1*/
 					*map->m_next_pgofs = pgofs + 1;
 				break;
 			default:
@@ -1679,17 +1751,18 @@ next_dnode:
 				goto sync_out;
 			}
 		}
+		/*异地更新逻辑结束*/
 		if (flag == F2FS_GET_BLOCK_PRE_AIO)
-			goto skip;
+			goto skip; /*实际上就是continue*/
 
 		if (map->m_multidev_dio)
 			bidx = f2fs_target_device_index(sbi, blkaddr);
 
-		if (map->m_len == 0) {
+		if (map->m_len == 0) { /*如果m_len还是处在刚初始化的阶段*/
 			/* reserved delalloc block should be mapped for fiemap. */
 			if (blkaddr == NEW_ADDR)
 				map->m_flags |= F2FS_MAP_DELALLOC;
-			/* DIO READ and hole case, should not map the blocks.*/
+			/* DIO READ and hole case, should not map the blocks. 为文件空洞的时候不建立映射?*/
 			if (!(flag == F2FS_GET_BLOCK_DIO && is_hole &&
 			      !map->m_may_create))
 				map->m_flags |= F2FS_MAP_MAPPED;
@@ -1701,11 +1774,11 @@ next_dnode:
 				map->m_bdev = FDEV(bidx).bdev;
 		} else if (map_is_mergeable(
 				   sbi, map, blkaddr, flag, bidx,
-				   ofs)) {
+				   ofs)) { /*重点代码,f2fs会尝试进行块映射合并,对读来说最重要*/
 			ofs++;
 			map->m_len++;
 		} else {
-			goto sync_out;
+			goto sync_out; /*不能合并直接break循环*/
 		}
 
 skip:
@@ -1746,13 +1819,15 @@ skip:
 		if (pgofs >= end)
 			goto sync_out;
 	} while (dn.ofs_in_node < end_offset);
+	// goto next_block;/*循环判断和跳转*/
+	/*后处理逻辑开始*/
 	if (flag == F2FS_GET_BLOCK_PRECACHE|| flag == F2FS_GET_BLOCK_IOMAP) {
 		if (map->m_flags & F2FS_MAP_MAPPED) {
 			unsigned int ofs = start_pgofs - map->m_lblk;
 
-			f2fs_update_read_extent_cache_range(&dn,
-				start_pgofs, map->m_pblk + ofs,
-				map->m_len - ofs);
+			f2fs_update_read_extent_cache_range(&dn, start_pgofs,
+							    map->m_pblk + ofs,
+							    map->m_len - ofs);
 		}
 	}
 
@@ -1771,8 +1846,8 @@ sync_out:
 		 * for hardware encryption, but to avoid potential issue
 		 * in future
 		 */
-		f2fs_wait_on_block_writeback_range(inode,
-						map->m_pblk, map->m_len);
+		f2fs_wait_on_block_writeback_range(inode, map->m_pblk,
+						   map->m_len);
 
 		if (map->m_multidev_dio) {
 			block_t blk_addr = map->m_pblk;
@@ -1784,20 +1859,20 @@ sync_out:
 
 			if (map->m_may_create)
 				f2fs_update_device_state(sbi, inode->i_ino,
-							blk_addr, map->m_len);
+							 blk_addr, map->m_len);
 
 			f2fs_bug_on(sbi, blk_addr + map->m_len >
-						FDEV(bidx).end_blk + 1);
+						 FDEV(bidx).end_blk + 1);
 		}
 	}
 
-	if (flag == F2FS_GET_BLOCK_PRECACHE) {
+	if (flag == F2FS_GET_BLOCK_PRECACHE||flag== F2FS_GET_BLOCK_IOMAP) {
 		if (map->m_flags & F2FS_MAP_MAPPED) {
 			unsigned int ofs = start_pgofs - map->m_lblk;
 
-			f2fs_update_read_extent_cache_range(&dn,
-				start_pgofs, map->m_pblk + ofs,
-				map->m_len - ofs);
+			f2fs_update_read_extent_cache_range(&dn, start_pgofs,
+							    map->m_pblk + ofs,
+							    map->m_len - ofs);
 		}
 		if (map->m_next_extent)
 			*map->m_next_extent = pgofs + 1;
@@ -2018,8 +2093,7 @@ next:
 	 * requery.
 	 */
 	if (!compr_cluster && (map.m_flags & F2FS_MAP_MAPPED) &&
-				map.m_lblk + map.m_len - 1 == last_blk &&
-				blk_len != max_len) {
+	    map.m_lblk + map.m_len - 1 == last_blk && blk_len != max_len) {
 		blk_len = max_len;
 		goto next;
 	}
@@ -2387,6 +2461,235 @@ out:
 	*bio_ret = bio;
 	return ret;
 }
+static int __f2fs_get_compressed_pblks_info(struct inode *inode, pgoff_t cluster_start_idx,
+				 struct f2fs_compressed_pblks_info *pblks_info)
+{
+	struct f2fs_sb_info *sbi = F2FS_I_SB(inode);
+	struct extent_info ei = {};
+	int ret = 0;
+	int i;
+
+	pblks_info->num_pblks = 0; // Initialize
+
+	if (f2fs_lookup_read_extent_cache(inode, cluster_start_idx, &ei)) {
+		pblks_info->is_from_extent = true;
+		pblks_info->blk_info.ei = ei;
+	} else {
+		pblks_info->is_from_extent = false;
+		set_new_dnode(&pblks_info->blk_info.dn, inode, NULL, NULL, 0);
+		ret = f2fs_get_dnode_of_data(&pblks_info->blk_info.dn,
+					     cluster_start_idx, LOOKUP_NODE);
+		if (ret)
+			return ret;
+
+		f2fs_bug_on(sbi, pblks_info->blk_info.dn.data_blkaddr !=
+					 COMPRESS_ADDR);
+	}
+	unsigned int max_possible_pblks = pblks_info->is_from_extent ?
+						  ei.c_len :
+						  F2FS_I(inode)->i_cluster_size;
+
+	for (i = 0; i < max_possible_pblks;
+	     i++) { // Check up to cluster_size physical blocks
+		block_t blkaddr;
+
+		if (pblks_info->is_from_extent) {
+			blkaddr = ei.blk + i;
+		} else {
+			blkaddr = data_blkaddr(
+				pblks_info->blk_info.dn.inode,
+				pblks_info->blk_info.dn
+					.node_folio, // node_folio in new kernels
+				pblks_info->blk_info.dn.ofs_in_node + i + 1);
+		}
+		if (!__is_valid_data_blkaddr(blkaddr)) // NULL_ADDR or BAD_ADDR
+			break;
+
+		if (!f2fs_is_valid_blkaddr(sbi, blkaddr, DATA_GENERIC)) {
+			// If not from extent, put dnode before returning error
+			if (!pblks_info->is_from_extent)
+				f2fs_put_dnode(&pblks_info->blk_info.dn);
+			return -EFAULT;
+		}
+		pblks_info->num_pblks++;
+	}
+	return 0;
+}
+static int
+f2fs_flush_compress_ctx_read(struct f2fs_compressed_pblks_info *cc_info,
+			     struct compress_ctx *cc, struct bio **bio_ret,struct readahead_control *rac)
+{
+	struct inode *inode = cc->inode;
+	struct f2fs_sb_info *sbi = F2FS_I_SB(inode);
+	struct decompress_io_ctx *dic = NULL;
+	struct bio *bio = *bio_ret;
+	int ret = 0;
+	int i;
+	unsigned int post_read_steps = 0;
+	if (f2fs_cluster_is_empty(cc))
+		return 0;
+	unsigned int num_blks = cc_info->num_pblks;
+
+	cc->nr_cpages = num_blks;
+
+	dic = f2fs_alloc_dic(cc);
+	if (IS_ERR(dic)) {
+		ret = PTR_ERR(dic);
+		goto out_err;
+	}
+	for (i = 0; i < cc->nr_cpages; i++) {
+		struct folio *cfolio = page_folio(
+			dic->cpages[i]); // Assumes dic has pages/folios
+		block_t blkaddr =
+			cc_info->is_from_extent ?
+				cc_info->blk_info.ei.blk + i :
+				data_blkaddr(cc_info->blk_info.dn.inode,cc_info->blk_info.dn.node_folio,cc_info->blk_info.dn.ofs_in_node +
+					     i + 1);
+		sector_t sector = (sector_t)blkaddr
+				  << sbi->log_sectors_per_block;
+		struct bio_post_read_ctx *post_ctx;
+		if (f2fs_load_compressed_folio(sbi, cfolio, blkaddr)) {
+			if (atomic_dec_and_test(&dic->remaining_pages)) {
+				f2fs_decompress_cluster(dic, true);
+				break;
+			}
+			continue;	
+		}
+		// Check BIO mergeability for compressed reads
+		if (bio && (bio_end_sector(bio) != sector || // Contiguity check
+			    !f2fs_crypt_mergeable_bio(bio, inode, cfolio->index,
+						      NULL))) {
+submit_and_realloc:
+			f2fs_submit_read_bio(sbi, bio, DATA);
+			bio = NULL;
+			*bio_ret=bio;
+		}
+
+		if (!bio) {
+			bio = f2fs_grab_read_bio(inode, blkaddr, cc->nr_cpages,
+						 f2fs_ra_op_flags(rac),
+						 cfolio->index, false);
+			if (IS_ERR(bio)) {
+				ret = PTR_ERR(bio);
+				bio = NULL;
+				f2fs_decompress_end_io(dic, ret,
+						       true); // Signal error
+				goto out_err; // Need proper error cleanup for cc
+			}
+			bio->bi_iter.bi_sector = sector; // Set start sector
+			*bio_ret = bio;
+		}
+
+		// Add the *compressed buffer folio* to the bio
+		if (!bio_add_folio(bio, cfolio, F2FS_BLKSIZE, 0))
+			goto submit_and_realloc;
+
+		// Setup post-read context for decompression
+		post_ctx = get_post_read_ctx(bio);
+		post_ctx->enabled_steps |= STEP_DECOMPRESS;
+		refcount_inc(&dic->refcnt);
+
+		inc_page_count(sbi, F2FS_RD_DATA);
+		f2fs_update_iostat(sbi, inode, FS_DATA_READ_IO, F2FS_BLKSIZE);
+	}
+out_err:
+	// Reads submitted/queued. Reset context state but keep arrays.
+	f2fs_destroy_compress_ctx(cc, false);
+	return ret; // Success
+}
+ 
+int f2fs_read_multi_folios(struct compress_ctx *cc, struct bio **bio_ret,
+			   struct readahead_control *rac, bool for_write)
+{
+	struct inode *inode = cc->inode;
+	struct f2fs_compressed_pblks_info pblks_info;
+	int ret = 0;
+	int i;
+	sector_t last_block_in_file = F2FS_BYTES_TO_BLK(
+		f2fs_readpage_limit(inode) + F2FS_BLKSIZE - 1);
+	unsigned int num_to_skip = 0;
+	for (i = 0; i < cc->cluster_size;i+=num_to_skip) {
+		struct page *page =
+			cc->rpages[i]; // These are target pages for decompression
+		struct folio *folio;
+
+		if (!page) // Slot in cluster might be empty
+		{
+			num_to_skip = 1;
+			continue;
+		}
+		folio = page_folio(page);
+		num_to_skip =min_t(unsigned int,folio_nr_pages(folio) - folio_page_idx(folio, page),cc->cluster_size - i);
+		if ((sector_t)(folio->index + folio_page_idx(folio, page)) >=
+		    last_block_in_file) 
+		{
+			folio_zero_segment(folio,folio_page_idx(folio, page) << PAGE_SHIFT,folio_size(folio)); // Zero this specific page within folio
+			struct f2fs_iomap_folio_state *fifs = folio->private;
+			if (folio_order(folio)>0&&fifs) 
+			{
+				iomap_set_range_uptodate(folio,folio_page_idx(folio, page)<< PAGE_SHIFT,folio_size(folio) - (folio_page_idx(folio, page)<< PAGE_SHIFT));
+			} else 
+			{
+				folio_mark_uptodate(folio);
+			}
+		}
+		else if(!folio_test_uptodate(folio))
+		{
+			continue;
+		}
+		if (for_write) {
+			f2fs_folio_put(folio, true);
+		} else {
+			folio_unlock(folio);
+		}
+		for(int j = i; j < num_to_skip; j++) {
+			cc->rpages[j] = NULL;
+		}
+		cc->nr_rpages -= num_to_skip;
+	}
+	if (f2fs_cluster_is_empty(cc)) {
+		*bio_ret = NULL;
+		return 0;
+	}
+	f2fs_bug_on(F2FS_I_SB(inode), cc->cluster_idx == NULL_CLUSTER);
+	ret = __f2fs_get_compressed_pblks_info(
+		inode, cc->cluster_idx << cc->log_cluster_size, &pblks_info);
+	if (ret)
+		goto out_error;
+
+	if (!pblks_info.is_from_extent && pblks_info.num_pblks == 0) {
+		ret = 0;
+		goto out_put_dnode;
+	}
+	ret = f2fs_flush_compress_ctx_read(&pblks_info, cc, bio_ret, rac);
+
+out_put_dnode:
+	if (!pblks_info.is_from_extent && pblks_info.blk_info.dn.node_folio) {
+		f2fs_put_dnode(&pblks_info.blk_info.dn);
+	}
+	if (ret) {
+		goto out_error;
+	}
+	return 0;
+
+out_error:
+	for (i = 0; i < cc->cluster_size;) {
+		if (cc->rpages[i]) {
+			struct folio *folio = page_folio(cc->rpages[i]);
+			folio_unlock(folio);
+			for (int j = folio_page_idx(folio, cc->rpages[i]);
+			     j < folio_nr_pages(folio); j++) {
+				cc->rpages[i] = NULL;
+				i++;
+				if (i >= cc->cluster_size)
+					break;
+			}
+		}
+	}
+	cc->nr_rpages = 0;
+	*bio_ret = NULL;
+	return ret;
+}
 #endif
 
 /*
@@ -2627,7 +2930,6 @@ bool f2fs_should_update_inplace(struct inode *inode, struct f2fs_io_info *fio)
 	/* if this is cold file, we should overwrite to avoid fragmentation */
 	if (file_is_cold(inode) && !is_inode_flag_set(inode, FI_OPU_WRITE))
 		return true;
-
 	return check_inplace_update_policy(inode, fio);
 }
 
@@ -2683,7 +2985,7 @@ static inline bool need_inplace_update(struct f2fs_io_info *fio)
 int f2fs_do_write_data_page(struct f2fs_io_info *fio)
 {
 	struct folio *folio = page_folio(fio->page);
-	struct inode *inode = folio->mapping->host;
+	struct inode* inode = folio->mapping->host;
 	struct dnode_of_data dn;
 	struct node_info ni;
 	bool ipu_force = false;
@@ -2720,7 +3022,12 @@ int f2fs_do_write_data_page(struct f2fs_io_info *fio)
 
 	fio->old_blkaddr = dn.data_blkaddr;
 
+<<<<<<< HEAD
 	/* This page is already truncated */
+=======
+	/* This page is already truncated 
+	比较可疑的代码。*/
+>>>>>>> b325a9a33911 (针对脏页写和压缩文件的大补丁)
 	if (fio->old_blkaddr == NULL_ADDR) {
 		folio_clear_uptodate(folio);
 		clear_page_private_gcing(folio_page(folio, 0));
@@ -2728,8 +3035,8 @@ int f2fs_do_write_data_page(struct f2fs_io_info *fio)
 	}
 got_it:
 	if (__is_valid_data_blkaddr(fio->old_blkaddr) &&
-		!f2fs_is_valid_blkaddr(fio->sbi, fio->old_blkaddr,
-						DATA_GENERIC_ENHANCE)) {
+	    !f2fs_is_valid_blkaddr(fio->sbi, fio->old_blkaddr,
+				   DATA_GENERIC_ENHANCE)) {
 		err = -EFSCORRUPTED;
 		goto out_writepage;
 	}
@@ -2979,15 +3286,179 @@ redirty_out:
 	folio_unlock(folio);
 	return err;
 }
+/*Write one dirty segment for one folio
+all the retry logic is moved to here from f2fs_write_raw_pages and f2fs_write_cache_folios */
+int f2fs_write_single_data_folio(struct folio *folio, int *submitted_pages_count,
+				struct bio **bio_ptr, sector_t *last_block_ptr,
+				struct writeback_control *wbc,
+				enum iostat_type io_type,int compr_blocks,
+				bool from_compress, bool is_reclaim,
+				u64 start, u64 end)
+{
+	struct inode *inode = folio->mapping->host;
+	struct f2fs_sb_info *sbi = F2FS_I_SB(inode);
+	int err = 0;
+	int local_submitted_count = 0;
+	if (folio_order(folio) == 0) {
+	retry_single:
+		err = f2fs_write_single_data_page(folio, &local_submitted_count,
+						    bio_ptr, last_block_ptr,
+						    wbc, io_type,
+						    compr_blocks,
+						    !is_reclaim); 
+		if (err == -EAGAIN) {
+			// f2fs_write_single_data_page does not unlock on -EAGAIN.
+			// We must unlock it before waiting.
+			folio_unlock(folio);
+			/*may come from f2fs_write_data_pages*/
+			if (wbc->sync_mode == WB_SYNC_ALL || f2fs_compressed_file(inode)) {
+				f2fs_io_schedule_timeout(DEFAULT_IO_TIMEOUT);
+				folio_lock(folio); 
+				if (unlikely(folio->mapping != inode->i_mapping ||
+					     !folio_test_dirty(folio))) {
+					return 0; 
+				}
+				goto retry_single;
+			}
+			return -EAGAIN;
+		}
+		if (submitted_pages_count)
+			*submitted_pages_count = local_submitted_count;
+		return err;
+	}
+	struct f2fs_iomap_folio_state *fifs = folio->private; 
+	WARN_ON_ONCE(!fifs);
+	pgoff_t folio_start_idx = (start - folio_pos(folio)) >> PAGE_SHIFT;
+	pgoff_t folio_end_idx = (end - 1 - folio_pos(folio)) >> PAGE_SHIFT;
 
+	for (pgoff_t i = folio_start_idx; i <= folio_end_idx; ++i) {
+		struct page *page = folio_page(folio, i);
+		struct f2fs_io_info fio = {
+			.sbi = sbi,
+			.ino = inode->i_ino,
+			.type = DATA,
+			.op = REQ_OP_WRITE,
+			.op_flags = wbc_to_write_flags(wbc),
+			.old_blkaddr = NULL_ADDR,
+			.page = page,
+			.encrypted_page = NULL,
+			.submitted = 0, 
+			.compr_blocks = compr_blocks, 
+			.need_lock = compr_blocks ? LOCK_DONE : LOCK_RETRY,
+			.meta_gc = f2fs_meta_inode_gc_required(inode) ? 1 : 0,
+			.io_type = io_type,
+			.io_wbc = wbc,
+			.bio = bio_ptr ? bio_ptr : NULL, 
+			.last_block = last_block_ptr
+		};
+	retry_multi:
+		atomic_add(PAGE_SIZE, &fifs->write_bytes_pending);
+		err=f2fs_do_write_data_page(&fio);
+		
+	/* No more unlock for large folio in retry write logic for now.
+	Because it will cause iomap_folio_state to become modified by buffered write
+	and handle partial truncate is tricky.There's no much benefit to unlock a large folio here*/
+		if (err == -EAGAIN) {
+			if (wbc->sync_mode == WB_SYNC_ALL || from_compress) {
+				f2fs_io_schedule_timeout(DEFAULT_IO_TIMEOUT);
+				fio.need_lock = LOCK_REQ;
+				goto retry_multi;
+			} else {
+				err = -EAGAIN;
+				goto handle_multi_err;
+			}
+		}
+		//TODO : for inplace write we should update bio and last_block.Need further reasearch.
+		// if (bio_ptr) *bio_ptr = fio.bio;
+		// if (last_block_ptr) *last_block_ptr = fio.last_block;
+handle_multi_err:
+		if (err) {
+			if (fifs) {
+				// If submission failed for this page, it won't go to f2fs_write_end_io
+				// for this portion.
+				if (!atomic_sub_and_test(PAGE_SIZE, &fifs->write_bytes_pending)) {
+					folio_end_writeback(folio);
+				}
+				bio_endio(*fio.bio);
+			}
+			break; 
+		} else {
+			local_submitted_count++;
+		}
+	}
+
+	if (submitted_pages_count)
+		*submitted_pages_count = local_submitted_count;
+
+	return err;
+}
+int f2fs_write_split_folio_range(struct address_space *mapping,
+					struct writeback_control *wbc,
+					enum iostat_type io_type,
+					pgoff_t start_index,
+					pgoff_t end_index,struct folio *first_folio)
+{
+	pgoff_t current_index = start_index;
+	struct folio *folio=first_folio;
+	int ret=0;
+	// Loop through the page indices of the original, unsplit folio.
+	while (current_index < end_index) {
+		
+		int submitted = 0;
+
+		// Find the folio that now covers current_index.
+		// Use FGP_LOCK to get it locked.
+		if(!folio)
+			folio = f2fs_filemap_get_folio(mapping, current_index, FGP_LOCK,GFP_KERNEL);
+		if (IS_ERR(folio)) {
+			// If page not found, it might have been fully truncated, which is ok.
+			if (PTR_ERR(folio) == -ENOENT) {
+				current_index++;
+				continue;
+			}
+			return PTR_ERR(folio);
+		}
+
+		if (unlikely(folio->mapping != mapping)) {
+			folio_unlock(folio);
+			folio_put(folio);
+			current_index = folio_next_index(folio);
+			continue;
+		}
+
+		if (folio_test_writeback(folio)) {
+			folio_wait_writeback(folio);
+		}
+
+		if (folio_test_dirty(folio) && folio_clear_dirty_for_io(folio)) {
+			// This new folio needs its writeback started.
+			folio_start_writeback(folio);
+			ret = f2fs_write_single_data_folio(folio, &submitted,
+							NULL, NULL, wbc, io_type,
+							0, false,false,
+							folio_pos(folio),
+							folio_pos(folio) + folio_size(folio));
+		}
+
+		// Advance index past the folio we just processed.
+		current_index = folio_next_index(folio);
+		folio_unlock(folio);
+		folio_put(folio);
+
+		if (ret)
+			break;
+		folio=NULL;
+	}
+	return ret;
+}
 /*
  * This function was copied from write_cache_pages from mm/page-writeback.c.
  * The major change is making write step of cold data page separately from
  * warm/hot data page.
  */
 static int f2fs_write_cache_pages(struct address_space *mapping,
-					struct writeback_control *wbc,
-					enum iostat_type io_type)
+				  struct writeback_control *wbc,
+				  enum iostat_type io_type)
 {
 	int ret = 0;
 	int done = 0, retry = 0;
@@ -3130,7 +3601,7 @@ readd:
 
 				ret2 = f2fs_prepare_compress_overwrite(
 							inode, &pagep,
-							folio->index, &fsdata);
+							folio->index, &fsdata,0);
 				if (ret2 < 0) {
 					ret = ret2;
 					done = 1;
@@ -3269,10 +3740,158 @@ next:
 #endif
 
 	return ret;
-}
+}	
 
+/*copy from iomap_writepages, but change it to support both normal and compressed file*/
+static int f2fs_write_cache_folios(struct address_space *mapping,
+				   struct writeback_control *wbc,
+				   enum iostat_type io_type)
+{
+	struct folio *folio = NULL; 
+	int err = 0;
+	struct inode *inode = mapping->host;
+	u64 pos = 0;
+	u64 end_pos = 0;
+	u64 end_aligned=0;
+	u32 r_len=0;
+	bool is_compressed_file = f2fs_compressed_file(inode);
+	// bool retry = false;
+	int submitted=0;
+	int nwritten=0;
+#ifdef CONFIG_F2FS_FS_COMPRESSION
+		struct compress_ctx cc = {
+		.inode = inode,
+		.log_cluster_size = F2FS_I(inode)->i_log_cluster_size,
+		.cluster_size = F2FS_I(inode)->i_cluster_size,
+		.cluster_idx = NULL_CLUSTER,
+		.rpages = NULL,
+		.nr_rpages = 0,
+		.cpages = NULL,
+		.valid_nr_cpages = 0,
+		.rbuf = NULL,
+		.cbuf = NULL,
+		.rlen = PAGE_SIZE * F2FS_I(inode)->i_cluster_size,
+		.private = NULL,
+	};
+	if(is_compressed_file)
+	{
+		f2fs_init_compress_ctx(&cc);
+	}
+#endif
+	if (get_dirty_pages(mapping->host) <=
+	    SM_I(F2FS_M_SB(mapping))->min_hot_blocks)
+		set_inode_flag(mapping->host, FI_HOT_DATA);
+	else
+		clear_inode_flag(mapping->host, FI_HOT_DATA);
+
+	while ((folio = writeback_iter(mapping, wbc, folio, &err))) {
+		struct f2fs_iomap_folio_state *fifs = NULL;
+		pos = folio_pos(folio);
+		end_pos = pos + folio_size(folio);
+		if (!iomap_writepage_handle_eof(folio, inode, &end_pos)) {
+			folio_unlock(folio);
+			return 0;
+		}
+		fifs = folio->private;
+		if (i_blocks_per_folio(inode, folio) > 1) {
+			if (!fifs) {
+				fifs = f2fs_ifs_alloc(folio, 0,true);
+				iomap_set_range_dirty(folio, 0, end_pos - pos);
+			}
+		}
+		/*We do not use a bias for fifs->write_bytes_pending here
+		because we dec writes_bytes_pending's length before every folio add 
+		to bio*/
+		folio_start_writeback(folio);
+		end_aligned = round_up(end_pos, i_blocksize(inode));
+		while ((r_len = f2fs_iomap_find_dirty_range(folio, &pos,
+						       end_aligned))) {
+			if (is_compressed_file) {
+				pgoff_t cluster_ix =
+					cluster_idx(&cc, pos >> PAGE_SHIFT);
+				if (cc.cluster_idx != NULL_CLUSTER &&
+				    cc.cluster_idx != cluster_ix) {
+					if (!f2fs_cluster_is_empty(&cc)) {
+
+						err = f2fs_write_multi_pages(&cc,&submitted,wbc, io_type);
+						// wbc->nr_to_write -= submitted_compress;
+						/* writeback_iter choose to dec folio_nr_pages(folio) in wbc->nr_to_write
+						 * It's completly different from the dec policy that f2fs choose in f2fs_write_cache_pages
+						 * it's an open problem here
+						*/
+						if (err) {
+							goto handle_current_folio_error;
+						}
+						f2fs_init_compress_ctx(&cc);
+					}
+				}
+				//TODO:Not fully understand the role of f2fs_prepare_compress_overwrite here.Comment it for now
+				// 
+				// if (f2fs_cluster_is_empty(&cc)) {
+				// 	cc.cluster_idx =
+				// 		cluster_ix; // Set for prepare_compress_overwrite
+				// 	err = f2fs_prepare_compress_overwrite(&cc, NULL,pos >>PAGE_SHIFT,NULL);
+				// 	if (err < 0) {
+				// 		goto handle_current_folio_error;
+				// 	}
+				// 	// After prepare_compress_overwrite, cc.cluster_idx is definitively set,
+				// 	// and cc.rpages might be filled if it was an overwrite.
+				// }
+				folio_get(folio); 
+				f2fs_compress_ctx_add_folio(&cc, folio,pos,r_len);
+				if (folio_order(folio)>0&&fifs) {
+					atomic_add(r_len, f2fs_ifs_dirty_bytes_pending_ptr(fifs, folio));
+				}
+			} else { 
+				err = f2fs_write_single_data_folio(folio, &submitted, NULL,
+					NULL, wbc, io_type, 0 ,false,false ,pos,pos +r_len);
+				if (err) {
+					goto handle_current_folio_error;
+				}
+			}
+			nwritten += submitted;
+			pos +=r_len; 
+		} 
+		iomap_clear_range_dirty(folio, 0, folio_size(folio));
+
+handle_current_folio_error: 
+		
+		if(!err&&fifs&&folio_order(folio)>0&&atomic_read(f2fs_ifs_dirty_bytes_pending_ptr(fifs, folio)) > 0)
+		{
+			// Parts of this folio are staged in compress_ctx. Defer unlock.
+			f2fs_set_folio_private_deferred_unlock(folio);
+		} 
+		else if(folio_test_locked(folio)){
+			// not staged,if the folio didn't be locked, unlock it.
+			folio_unlock(folio);
+		}
+		if(!submitted)
+		{
+			// none of the folio's part go to writeback,we manually end_writeback after unlock it
+			if(folio_test_writeback(folio))
+				folio_end_writeback(folio);
+		}
+		if(err)
+		{ 
+			break;
+		}
+	} 
+
+	if (is_compressed_file && !f2fs_cluster_is_empty(&cc)) {
+		err  = f2fs_write_multi_pages(&cc, &submitted,
+						       wbc, io_type);
+		nwritten += submitted;
+	}
+	if (is_compressed_file) {
+		f2fs_destroy_compress_ctx(&cc,false);
+	}
+	if (nwritten)
+		f2fs_submit_merged_write_cond(F2FS_M_SB(mapping), mapping->host,
+								NULL, 0, DATA);
+	return err;
+}
 static inline bool __should_serialize_io(struct inode *inode,
-					struct writeback_control *wbc)
+					 struct writeback_control *wbc)
 {
 	/* to avoid deadlock in path of data flush */
 	if (F2FS_I(inode)->wb_task)
@@ -3293,8 +3912,8 @@ static inline bool __should_serialize_io(struct inode *inode,
 }
 
 static int __f2fs_write_data_pages(struct address_space *mapping,
-						struct writeback_control *wbc,
-						enum iostat_type io_type)
+				   struct writeback_control *wbc,
+				   enum iostat_type io_type)
 {
 	struct inode *inode = mapping->host;
 	struct f2fs_sb_info *sbi = F2FS_I_SB(inode);
@@ -3338,7 +3957,12 @@ static int __f2fs_write_data_pages(struct address_space *mapping,
 	}
 
 	blk_start_plug(&plug);
-	ret = f2fs_write_cache_pages(mapping, wbc, io_type);
+	if(f2fs_should_use_buffered_iomap(inode))
+	{
+		ret =f2fs_write_cache_folios(mapping, wbc, io_type);
+	}
+	else
+		ret = f2fs_write_cache_pages(mapping, wbc, io_type);
 	blk_finish_plug(&plug);
 
 	if (locked)
@@ -3577,9 +4201,14 @@ reserve_block:
 		*blk_addr = ori_blk_addr;
 	return 0;
 }
+<<<<<<< HEAD
 
+=======
+//
+>>>>>>> b325a9a33911 (针对脏页写和压缩文件的大补丁)
 static int f2fs_write_begin(struct file *file, struct address_space *mapping,
-		loff_t pos, unsigned len, struct folio **foliop, void **fsdata)
+			    loff_t pos, unsigned len, struct folio **foliop,
+			    void **fsdata)
 {
 	struct inode *inode = mapping->host;
 	struct f2fs_sb_info *sbi = F2FS_I_SB(inode);
@@ -3619,7 +4248,7 @@ static int f2fs_write_begin(struct file *file, struct address_space *mapping,
 			goto repeat;
 
 		ret = f2fs_prepare_compress_overwrite(inode, &page,
-							index, fsdata);
+							index, fsdata,0);
 		if (ret < 0) {
 			err = ret;
 			goto fail;
@@ -3790,6 +4419,7 @@ void f2fs_invalidate_folio(struct folio *folio, size_t offset, size_t length)
 			f2fs_remove_dirty_inode(inode);
 		}
 	}
+	// clear_page_private_all(&folio->page);
 	if (offset == 0 && length == folio_size(folio)) {
 		WARN_ON_ONCE(folio_test_writeback(folio));
 		folio_cancel_dirty(folio);
@@ -4352,6 +4982,244 @@ const struct iomap_ops f2fs_buffered_read_iomap_ops = {
 };
 
  
+static int f2fs_buffered_read_compress_iomap_begin(struct inode *inode,
+						   loff_t pos, loff_t length,
+						   unsigned flags,
+						   struct iomap *iomap,
+						   struct iomap *srcmap)
+{
+	struct f2fs_sb_info *sbi = F2FS_I_SB(inode);
+	pgoff_t index = pos >> PAGE_SHIFT;
+	loff_t map_len_bytes;
+	int ret = 0;
+	iomap->bdev = sbi->sb->s_bdev;
+	iomap->private = NULL;
+	iomap->flags = 0;
+	iomap->offset = F2FS_BLK_TO_BYTES(F2FS_BYTES_TO_BLK(pos));
+#ifdef CONFIG_F2FS_FS_COMPRESSION
+	struct compress_ctx cc = {
+		.inode = inode,
+		.log_cluster_size = F2FS_I(inode)->i_log_cluster_size,
+		.cluster_size = F2FS_I(inode)->i_cluster_size,
+		.cluster_idx = NULL_CLUSTER,
+		.rpages = NULL,
+		.cpages = NULL,
+		.nr_rpages = 0,
+		.nr_cpages = 0,
+	};
+	/* For compress cluster,just fill iomap length with a cluster size
+	then all block mapping logic left for f2fs_write_multi_folio
+	to handle*/
+	if (f2fs_compressed_file(inode)) {
+		bool is_compressed = f2fs_is_compressed_cluster(inode, index);
+		if (is_compressed) {
+			pgoff_t cluster_start_idx =cluster_idx(&cc, index);
+			map_len_bytes = min_t(loff_t, length,
+					      ((loff_t)(cluster_start_idx + 1)<< cc.log_cluster_size)-index)<<PAGE_SHIFT;
+			iomap->length = map_len_bytes;
+				iomap->type = IOMAP_MAPPED;
+			return 0; 
+		}
+	}
+#endif
+	return f2fs_buffered_read_iomap_ops.iomap_begin(inode, pos, length,
+							flags, iomap, srcmap);
+}
+const struct iomap_ops f2fs_buffered_read_compress_iomap_ops = {
+.iomap_begin = f2fs_buffered_read_compress_iomap_begin,
+};
+void f2fs_init_readpage_ctx(struct f2fs_readpage_ctx *ctx,
+			    struct readahead_control *rac)
+{
+	struct inode *inode = rac->mapping->host;
+	ctx->rac = rac;
+	ctx->cur_folio = NULL;
+	ctx->bio=NULL;
+#ifdef CONFIG_F2FS_FS_COMPRESSION
+	ctx->cc.log_cluster_size = F2FS_I(inode)->i_log_cluster_size;
+	ctx->cc.cluster_size = 1 << ctx->cc.log_cluster_size;
+	ctx->cc.cluster_idx=NULL_CLUSTER;
+	ctx->cc.rpages = NULL;
+	ctx->cc.cpages = NULL;
+	ctx->cc.nr_rpages = 0;
+	ctx->cc.nr_cpages = 0;
+	ctx->cc.inode=inode;
+#endif
+}
+ 
+static int f2fs_compress_readpage_iter(struct iomap_iter *iter,struct f2fs_readpage_ctx *ctx)
+{
+	loff_t pos = iter->pos;
+	loff_t length = iomap_length(iter);
+	struct folio *folio = ctx->cur_folio;
+	struct inode* inode=folio->mapping->host;
+	struct f2fs_iomap_folio_state *fifs;
+	size_t poff, plen;
+	int ret;
+#ifdef CONFIG_F2FS_FS_COMPRESSION
+	bool is_compressed =
+		f2fs_is_compressed_cluster(inode, pos >> PAGE_SHIFT);
+#endif
+	/* zero post-eof blocks as the page may be mapped */
+	fifs = f2fs_ifs_alloc(folio, iter->flags,false);
+	iomap_adjust_read_range(iter->inode, folio, &pos, length, &poff, &plen);
+	if (plen == 0)
+		goto done;
+	if(!is_compressed)
+	{
+		if (iomap_block_needs_zeroing(iter, pos)) {
+			folio_zero_range(folio, poff, plen);
+			iomap_set_range_uptodate(folio, poff, plen);
+			goto done;
+		}
+	}
+	if (is_compressed) {
+		ret = f2fs_do_read_multi_folios(ctx,pos,plen);
+	} else {
+		ret = f2fs_do_read_single_folio_iomap(iter, ctx, pos, plen, poff);
+	}
+	if(ret)
+		return ret;
+done:
+	length = pos - iter->pos + plen;
+	return iomap_iter_advance(iter, &length);
+}
+
+static loff_t f2fs_compress_readahead_iter(struct iomap_iter *iter,struct f2fs_readpage_ctx *ctx)
+{
+	int ret = 0;
+	while (iomap_length(iter)) {
+		if (ctx->cur_folio &&offset_in_folio(ctx->cur_folio, iter->pos) == 0) {
+			if (!ctx->cur_folio_in_bio &&
+			    !ctx->cur_folio_in_compress_ctx)
+				folio_unlock(ctx->cur_folio);
+			ctx->cur_folio = NULL;
+		}
+		if (!ctx->cur_folio) {
+			ctx->cur_folio = readahead_folio(ctx->rac);
+			ctx->cur_folio_in_bio = false;
+			ctx->cur_folio_in_compress_ctx=false;
+		}
+		ret = f2fs_compress_readpage_iter(iter, ctx);
+		if (ret)
+			return ret;
+	}
+	return 0;
+}
+
+int f2fs_compress_iomap_readahead(struct inode *inode,
+				  struct readahead_control *rac)
+{
+	struct f2fs_readpage_ctx ctx;
+	int ret = 0;
+	f2fs_init_readpage_ctx(&ctx, rac);
+	struct iomap_iter iter = {
+		.inode = inode,
+		.pos = readahead_pos(rac),
+		.len = readahead_length(rac),
+	};
+	while ((ret = iomap_iter(
+			&iter, &f2fs_buffered_read_compress_iomap_ops)) > 0) {
+		iter.status = f2fs_compress_readahead_iter(&iter, &ctx);
+	}
+	if (ctx.bio) {
+		f2fs_submit_read_bio(
+			F2FS_I_SB(inode), ctx.bio,
+			 DATA);
+		ctx.bio = NULL;
+	}
+	if (ctx.cur_folio && !ctx.cur_folio_in_bio &&
+	    !ctx.cur_folio_in_compress_ctx) {
+		folio_unlock(ctx.cur_folio);
+	}
+	// f2fs_destroy_readpage_ctx(&ctx);
+	return ret;	
+}
+ 
+int f2fs_do_read_multi_folios(struct f2fs_readpage_ctx* ctx, loff_t pos,loff_t plen)
+{
+	struct folio *folio = ctx->cur_folio;
+	struct compress_ctx*cc=&ctx->cc;
+	struct bio** bio_ret = &ctx->bio;
+	pgoff_t cur_idx = pos >> PAGE_SHIFT;
+	struct readahead_control *rac = ctx->rac;
+	int ret = 0;	
+	pgoff_t cluster_ix = cluster_idx(cc,cur_idx);
+	if (cc->cluster_idx == NULL_CLUSTER)
+	{
+		ret = f2fs_init_compress_ctx(cc);
+		if (ret < 0)
+			return ret;
+	}
+	ctx->cur_folio_in_compress_ctx = true;
+	ret =do_read_multi_folios(cc, folio, pos, plen,bio_ret,rac,false);
+	return ret;
+}
+int do_read_multi_folios(struct compress_ctx*cc, struct folio *folio, loff_t pos,
+				  loff_t plen, struct bio** bio_ret,
+				  struct readahead_control *rac,bool for_write)
+{ 
+	int ret = 0;
+	f2fs_compress_ctx_add_folio(cc, folio, pos,plen);
+	struct f2fs_iomap_folio_state* fifs = folio->private;
+	if(folio_order(folio)>0&&fifs)
+	{
+		spin_lock_irq(&fifs->state_lock);
+		fifs->read_bytes_pending += plen;
+		spin_unlock_irq(&fifs->state_lock);
+	}
+	/* No more flushing compress ctx rpages and cpages to io
+	when a new folio's cluster index change,but flush immediately when cc
+	is full or this is the last folio in rac*/
+	if (f2fs_cluster_is_full(cc) || (rac&&rac->_nr_pages == 0)) {
+		ret = f2fs_read_multi_folios(cc, bio_ret,rac,for_write);
+		f2fs_destroy_compress_ctx(cc, false);
+	}
+	return ret;
+}
+int f2fs_do_read_single_folio_iomap(struct iomap_iter *iter,
+				    struct f2fs_readpage_ctx *ctx, loff_t pos,
+				    loff_t plen, loff_t poff)
+{
+	int ret = 0;
+	ctx->cur_folio_in_bio = true;
+	struct inode *inode = iter->inode;
+	struct folio *folio = ctx->cur_folio;
+	struct f2fs_iomap_folio_state *fifs = folio->private;
+	if (fifs) {
+		spin_lock_irq(&fifs->state_lock);
+		fifs->read_bytes_pending += plen;
+		spin_unlock_irq(&fifs->state_lock);
+	}
+	sector_t sector = iomap_sector(&iter->iomap, pos);
+	block_t block_nr = F2FS_BYTES_TO_BLK(iter->iomap.addr + pos - iter->iomap.offset);
+	pgoff_t first_index = pos >> PAGE_SHIFT;
+	unsigned int nr_vecs = DIV_ROUND_UP(plen, PAGE_SIZE);
+	if (ctx->bio && (bio_end_sector(ctx->bio) != sector)) {
+submit_and_realloc:
+		f2fs_submit_read_bio(F2FS_I_SB(inode), ctx->bio, DATA);
+		ctx->bio = NULL;
+	}
+	if (ctx->bio == NULL) {
+		ctx->bio = f2fs_grab_read_bio(inode, block_nr, nr_vecs,
+					      f2fs_ra_op_flags(ctx->rac), first_index,
+					      false);
+		if (IS_ERR(ctx->bio)) {
+			ret = PTR_ERR(ctx->bio);
+			ctx->bio = NULL;
+			ctx->cur_folio_in_bio = false;
+			return ret;
+		}
+	}
+
+	if (!bio_add_folio(ctx->bio, folio, plen, poff))
+		goto submit_and_realloc;
+
+	inc_page_count_multiple(F2FS_I_SB(inode), F2FS_RD_DATA,folio_nr_pages(folio));
+	f2fs_update_iostat(F2FS_I_SB(inode), NULL, FS_DATA_READ_IO,
+			   F2FS_BLKSIZE);
+	return ret;
+}
 static void f2fs_iomap_readahead(struct readahead_control *rac)
 {
 	struct inode *inode = rac->mapping->host;
@@ -4362,7 +5230,10 @@ static void f2fs_iomap_readahead(struct readahead_control *rac)
 	/* If the file has inline data, skip readahead */
 	if (f2fs_has_inline_data(inode))
 		return;
-	iomap_readahead(rac, &f2fs_buffered_read_iomap_ops);
+	if  (f2fs_compressed_file(inode))
+		f2fs_compress_iomap_readahead(inode, rac);
+	else
+		iomap_readahead(rac, &f2fs_buffered_read_iomap_ops);
 }
  
 static int f2fs_buffered_write_iomap_begin(struct inode *inode, loff_t pos, loff_t length,
@@ -4376,6 +5247,137 @@ static int f2fs_buffered_write_iomap_begin(struct inode *inode, loff_t pos, loff
 	iomap->offset = pos; 
 	iomap->bdev = sbi->sb->s_bdev; // Default block device
 	iomap->folio_ops = &f2fs_iomap_folio_ops;
+#ifdef CONFIG_F2FS_FS_COMPRESSION
+	pgoff_t index = pos >> PAGE_SHIFT;
+	struct compress_ctx cc = {
+			.inode = inode,
+			.log_cluster_size = F2FS_I(inode)->i_log_cluster_size,
+			.cluster_size = F2FS_I(inode)->i_cluster_size,
+			.cluster_idx = cluster_i_idx(inode,index),
+		};
+	if (pos<i_size_read(inode)&&f2fs_compressed_file(inode)&&f2fs_is_compressed_cluster(inode,index)) {
+		length=min_t(loff_t,length,i_size_read(inode)-pos);
+		struct iomap_iter* iter=container_of(iomap,struct iomap_iter,iomap);
+		struct bio*bio=NULL;
+		loff_t new_pos = pos;
+		size_t poff;
+		size_t plen;
+		pgoff_t start_idx = start_idx_of_cluster(&cc);//Aligned to cluster's start page index
+		pgoff_t end_idx = ((pos+length)>>PAGE_SHIFT)-1;
+		end_idx = end_idx_of_cluster(&cc,end_idx);//Aligned end idx to the last cluster's end
+		loff_t aligned_len=(end_idx-start_idx+1)<<PAGE_SHIFT;
+		struct folio*folio=iomap_get_folio(iter,start_idx<<PAGE_SHIFT,aligned_len);
+		if (folio_test_uptodate(folio))
+		{
+			iomap->length+=min_t(unsigned int,folio_nr_pages(folio)<<PAGE_SHIFT,length);
+			goto setup_iomap;
+		}
+		struct f2fs_iomap_folio_state* fifs=f2fs_ifs_alloc(folio, iter->flags,false);
+		if(folio_order(folio)>0&&fifs)
+		{
+			unsigned long flags;
+			spin_lock_irqsave(&fifs->state_lock, flags);
+			fifs->read_bytes_pending+=1;//Add a bias for read bytes_pending so folio_end_read will never be called
+			spin_unlock_irqrestore(&fifs->state_lock, flags);
+		}
+		iomap_adjust_read_range(inode,folio,&new_pos,aligned_len,&poff, &plen);
+		end_idx =min(end_idx,folio->index+folio_nr_pages(folio));
+		for (int i=cluster_idx(&cc,new_pos>>PAGE_SHIFT)<<cc.log_cluster_size;;)
+		{
+    		if (cc.nr_cpages==NULL)
+			{
+			err = f2fs_init_compress_ctx(&cc);
+			if (err < 0)
+			goto out_unlock;
+			}
+    		loff_t add_len=min(cc.cluster_size,end_idx-i+1)<<PAGE_SHIFT;
+    		do_read_multi_folios(&cc,folio,i<<PAGE_SHIFT,add_len,&bio,0,true);
+			iomap->length+=add_len;
+    		i+=cc.cluster_size;
+    		if(i>=end_idx||!f2fs_is_compressed_cluster(cc.inode, i))
+        		break;
+		}
+		bool last_cluster_is_partial=false;
+		if(f2fs_cluster_is_partial_full(&cc))
+		{
+			last_cluster_is_partial=true;
+			for (pgoff_t idx = end_idx+1; idx < end_idx_of_cluster(&cc,end_idx); idx++) {
+				struct folio *extra_folio = iomap_get_folio(iter, (loff_t)idx << PAGE_SHIFT, PAGE_SIZE);
+				if (IS_ERR(extra_folio)) { 
+					f2fs_folio_put(extra_folio,true);
+				 }
+				do_read_multi_folios(&cc, extra_folio, (loff_t)idx << PAGE_SHIFT, PAGE_SIZE, &bio, NULL, true);
+			}
+		}
+		if (bio)
+			f2fs_submit_read_bio(sbi, bio, DATA);
+		if (folio_order(folio)>0&&fifs) {
+			/*We use read_bytes_pending to wait for the whole folio to be read
+			We didn't use submit_bio_wait because folio can cross multi bios
+			*/
+			
+			for(;;)
+			{
+				bool done;
+				unsigned long flags;
+				spin_lock_irqsave(&fifs->state_lock, flags);
+				done = (fifs->read_bytes_pending == F2FS_IFS_MAGIC+1);
+				spin_unlock_irqrestore(&fifs->state_lock, flags);
+				if (done)
+					break;
+				f2fs_io_schedule_timeout(DEFAULT_IO_TIMEOUT);
+			}
+		}	
+			if (last_cluster_is_partial) {
+				// fill last unfull cluster if necessary
+				pgoff_t cluster_start = cluster_idx(&cc, index)<<cc.log_cluster_size;
+				err = f2fs_wait_cluster_uptodate(inode, end_idx+1, cc.cluster_size);
+				if (err) goto out_clean_bias;
+			}
+		if(folio_order(folio)>0&&fifs)
+		{
+			spin_lock_irqsave(&fifs->state_lock, flags);
+			fifs->read_bytes_pending-=1;//Add a bias for read bytes_pending so folio_end_read will never be called
+			spin_unlock_irqrestore(&fifs->state_lock, flags);
+		}
+		setup_iomap:
+		iomap->private = folio; 
+		iomap->type = IOMAP_MAPPED; 
+		iomap->addr = IOMAP_NULL_ADDR; 
+		iomap->offset = pos;
+		iomap->bdev = sbi->sb->s_bdev;
+		return 0;
+		out_unlock:
+		folio_unlock(folio);
+		folio_put(folio);
+		out_clean_bias:
+		if (fifs)
+		{
+			spin_lock_irqsave(&fifs->state_lock, flags);
+			fifs->read_bytes_pending-=1;
+			spin_unlock_irqrestore(&fifs->state_lock, flags);
+		}
+		return err;
+		}
+		
+        // pgoff_t index = pos >> PAGE_SHIFT;
+		// pgoff_t cluster_idx =cluster_i_idx(inode,index);
+		// pgoff_t end_idx_of_cluster= i_end_idx_of_cluster(inode,index);
+        // err=f2fs_prepare_compress_overwrite(inode, NULL,index,&iomap->private,0);
+		// if(err<0)
+		// 		return err;
+		// if(err>0) 
+		// {
+        // 	iomap->type = IOMAP_MAPPED; 
+        // 	iomap->addr = IOMAP_NULL_ADDR;
+        // 	iomap->offset = pos;
+        // 	loff_t cluster_end_pos = (loff_t)end_idx_of_cluster << PAGE_SHIFT;
+        // 	loff_t bytes_to_cluster_end = cluster_end_pos - pos;
+        // 	iomap->length = min(length, bytes_to_cluster_end);
+        // 	return 0;
+		// }
+    
+#endif
 	if (f2fs_has_inline_data(inode)) {
 		// If the write starts and fits entirely within the inline area
 		if (pos + length <= MAX_INLINE_DATA(inode)) {
@@ -4454,7 +5456,16 @@ out:
 static int f2fs_buffered_write_iomap_end(struct inode *inode, loff_t pos,
         loff_t length, ssize_t written, unsigned flags, struct iomap *iomap)
 {
-    return written;
+    #ifdef CONFIG_F2FS_FS_COMPRESSION
+	// if (f2fs_compressed_file(inode) && iomap->private) {
+	// 	/*index parameter of f2fs_compress_write_end 
+	// 	has no use in buffer write context*/
+	// 	f2fs_compress_write_end(inode, iomap->private, 0, written);
+	// 	f2fs_update_time(F2FS_I_SB(inode), REQ_TIME);
+	// 	return written;
+	// }
+	#endif
+    return 0;
 }
 const struct iomap_ops f2fs_buffered_write_iomap_ops = {
 	.iomap_begin = f2fs_buffered_write_iomap_begin,
@@ -4470,15 +5481,36 @@ const struct address_space_operations f2fs_iomap_aops = {
 	.write_end = f2fs_write_end,
 	.writepages		= f2fs_write_data_pages,
 	.dirty_folio		= f2fs_dirty_data_folio,
+	// .bmap			= f2fs_bmap,
 	.invalidate_folio	= f2fs_invalidate_folio,
 	.release_folio		= f2fs_release_folio,
-	.migrate_folio		= filemap_migrate_folio,
+	// .direct_IO		= noop_direct_IO,
+	// .migrate_folio		= filemap_migrate_folio,
 	.is_partially_uptodate  = iomap_is_partially_uptodate,
-	.error_remove_page	= generic_error_remove_page,
+	// .error_remove_page	= generic_error_remove_page,
+	// .swap_activate		= f2fs_iomap_swap_activate,
 };
 const struct iomap_folio_ops f2fs_iomap_folio_ops = {
+	.get_folio = f2fs_iomap_get_folio,
 	.put_folio = f2fs_iomap_put_folio,
 };
+struct folio* f2fs_iomap_get_folio(struct iomap_iter *iter, loff_t pos,
+			unsigned len)
+{
+	struct inode *inode = iter->inode;
+	pgoff_t index = pos >> PAGE_SHIFT;
+	// if(iter->iomap.private&&f2fs_compressed_file(inode))
+	// {
+	// 	struct page**rpages=iter->iomap.private;
+	// 	return page_folio(rpages[offset_i_in_cluster(inode, index)]);
+	// }
+	if(iter->iomap.private&&f2fs_compressed_file(inode))
+	{
+		return (struct folio*)iter->iomap.private;
+	}
+	else
+		return iomap_get_folio(iter, pos, len);
+}
 void f2fs_iomap_put_folio(struct inode *inode, loff_t pos, unsigned copied,
 			  struct folio *folio)
 {

--- a/fs/f2fs/data.c
+++ b/fs/f2fs/data.c
@@ -20,11 +20,14 @@
 #include <linux/sched/signal.h>
 #include <linux/fiemap.h>
 #include <linux/iomap.h>
+#include <linux/slab.h>
+#include <linux/highmem.h>
 
 #include "f2fs.h"
 #include "node.h"
 #include "segment.h"
 #include "iostat.h"
+#include "f2fs_ifs.h"
 #include <trace/events/f2fs.h>
 
 #define NUM_PREALLOC_POST_READ_CTXS	128
@@ -142,7 +145,7 @@ static void f2fs_finish_read_bio(struct bio *bio, bool in_task)
 	bio_for_each_folio_all(fi, bio) {
 		struct folio *folio = fi.folio;
 
-		if (f2fs_is_compressed_page(&folio->page)) {
+		if (f2fs_is_compressed_folio(folio)) {
 			if (ctx && !ctx->decompression_attempted)
 				f2fs_end_read_compressed_page(&folio->page, true, 0,
 							in_task);
@@ -187,7 +190,7 @@ static void f2fs_verify_bio(struct work_struct *work)
 		bio_for_each_segment_all(bv, bio, iter_all) {
 			struct page *page = bv->bv_page;
 
-			if (!f2fs_is_compressed_page(page) &&
+			if (!f2fs_is_compressed_folio(page_folio(page)) &&
 			    !fsverity_verify_page(page)) {
 				bio->bi_status = BLK_STS_IOERR;
 				break;
@@ -241,7 +244,7 @@ static void f2fs_handle_step_decompress(struct bio_post_read_ctx *ctx,
 	bio_for_each_segment_all(bv, ctx->bio, iter_all) {
 		struct page *page = bv->bv_page;
 
-		if (f2fs_is_compressed_page(page))
+		if (f2fs_is_compressed_folio(page_folio(page)))
 			f2fs_end_read_compressed_page(page, false, blkaddr,
 						      in_task);
 		else
@@ -339,7 +342,7 @@ static void f2fs_write_end_io(struct bio *bio)
 		}
 
 #ifdef CONFIG_F2FS_FS_COMPRESSION
-		if (f2fs_is_compressed_page(&folio->page)) {
+		if (f2fs_is_compressed_folio(folio)) {
 			f2fs_compress_write_end_io(bio, &folio->page);
 			continue;
 		}
@@ -564,7 +567,7 @@ static bool __has_merged_page(struct bio *bio, struct inode *inode,
 			if (IS_ERR(target))
 				continue;
 		}
-		if (f2fs_is_compressed_page(&target->page)) {
+		if (f2fs_is_compressed_folio(target)) {
 			target = f2fs_compress_control_folio(target);
 			if (IS_ERR(target))
 				continue;
@@ -707,7 +710,7 @@ int f2fs_submit_page_bio(struct f2fs_io_info *fio)
 
 	f2fs_set_bio_crypt_ctx(bio, fio_folio->mapping->host,
 			fio_folio->index, fio, GFP_NOIO);
-	bio_add_folio_nofail(bio, data_folio, folio_size(data_folio), 0);
+	bio_add_folio_nofail(bio, data_folio, PAGE_SIZE, folio_page_idx(data_folio,fio->encrypted_page ?fio->encrypted_page:fio->page)<<PAGE_SHIFT);
 
 	if (fio->io_wbc && !is_read_io(fio->op))
 		wbc_account_cgroup_owner(fio->io_wbc, fio_folio, PAGE_SIZE);
@@ -946,6 +949,7 @@ static bool is_end_zone_blkaddr(struct f2fs_sb_info *sbi, block_t blkaddr)
 
 void f2fs_submit_page_write(struct f2fs_io_info *fio)
 {
+	struct inode *inode = fio_inode(fio);
 	struct f2fs_sb_info *sbi = fio->sbi;
 	enum page_type btype = PAGE_TYPE_OF_BIO(fio->type);
 	struct f2fs_bio_info *io = sbi->write_io[btype] + fio->temp;
@@ -1528,8 +1532,11 @@ static bool map_is_mergeable(struct f2fs_sb_info *sbi,
 		return true;
 	if (flag == F2FS_GET_BLOCK_PRE_DIO)
 		return true;
-	if (flag == F2FS_GET_BLOCK_DIO &&
-		map->m_pblk == NULL_ADDR && blkaddr == NULL_ADDR)
+	if (flag == F2FS_GET_BLOCK_DIO && map->m_pblk == NULL_ADDR &&
+	    blkaddr == NULL_ADDR)
+		return true;
+	if (flag == F2FS_GET_BLOCK_IOMAP && map->m_pblk == NULL_ADDR &&
+	    blkaddr == NULL_ADDR)
 		return true;
 	return false;
 }
@@ -1590,145 +1597,156 @@ next_dnode:
 	prealloc = 0;
 	last_ofs_in_node = ofs_in_node = dn.ofs_in_node;
 	end_offset = ADDRS_PER_PAGE(&dn.node_folio->page, inode);
-
-next_block:
-	blkaddr = f2fs_data_blkaddr(&dn);
-	is_hole = !__is_valid_data_blkaddr(blkaddr);
-	if (!is_hole &&
-	    !f2fs_is_valid_blkaddr(sbi, blkaddr, DATA_GENERIC_ENHANCE)) {
-		err = -EFSCORRUPTED;
-		goto sync_out;
-	}
-
-	/* use out-place-update for direct IO under LFS mode */
-	if (map->m_may_create && (is_hole ||
-		(flag == F2FS_GET_BLOCK_DIO && f2fs_lfs_mode(sbi) &&
-		!f2fs_is_pinned_file(inode)))) {
-		if (unlikely(f2fs_cp_error(sbi))) {
-			err = -EIO;
-			goto sync_out;
-		}
-
-		switch (flag) {
-		case F2FS_GET_BLOCK_PRE_AIO:
-			if (blkaddr == NULL_ADDR) {
-				prealloc++;
-				last_ofs_in_node = dn.ofs_in_node;
-			}
-			break;
-		case F2FS_GET_BLOCK_PRE_DIO:
-		case F2FS_GET_BLOCK_DIO:
-			err = __allocate_data_block(&dn, map->m_seg_type);
-			if (err)
-				goto sync_out;
-			if (flag == F2FS_GET_BLOCK_PRE_DIO)
-				file_need_truncate(inode);
-			set_inode_flag(inode, FI_APPEND_WRITE);
-			break;
-		default:
-			WARN_ON_ONCE(1);
-			err = -EIO;
-			goto sync_out;
-		}
-
-		blkaddr = dn.data_blkaddr;
-		if (is_hole)
-			map->m_flags |= F2FS_MAP_NEW;
-	} else if (is_hole) {
-		if (f2fs_compressed_file(inode) &&
-		    f2fs_sanity_check_cluster(&dn)) {
+	do {
+		blkaddr = f2fs_data_blkaddr(&dn);
+		is_hole = !__is_valid_data_blkaddr(
+			blkaddr);
+		if (!is_hole && !f2fs_is_valid_blkaddr(sbi, blkaddr,
+						       DATA_GENERIC_ENHANCE)) {
 			err = -EFSCORRUPTED;
-			f2fs_handle_error(sbi,
-					ERROR_CORRUPTED_CLUSTER);
 			goto sync_out;
 		}
 
-		switch (flag) {
-		case F2FS_GET_BLOCK_PRECACHE:
-			goto sync_out;
-		case F2FS_GET_BLOCK_BMAP:
-			map->m_pblk = 0;
-			goto sync_out;
-		case F2FS_GET_BLOCK_FIEMAP:
-			if (blkaddr == NULL_ADDR) {
+		/* use out-place-update for direct IO under LFS mode */
+		if (map->m_may_create &&
+		    (is_hole ||
+		     (flag == F2FS_GET_BLOCK_DIO && f2fs_lfs_mode(sbi) &&
+		      !f2fs_is_pinned_file(inode)))) {
+			if (unlikely(f2fs_cp_error(sbi))) {
+				err = -EIO;
+				goto sync_out;
+			}
+
+			switch (flag) {
+			case F2FS_GET_BLOCK_PRE_AIO:
+				if (blkaddr == NULL_ADDR) {
+					prealloc++;
+					last_ofs_in_node = dn.ofs_in_node;
+				}
+				break;
+			case F2FS_GET_BLOCK_PRE_DIO:
+			case F2FS_GET_BLOCK_DIO:
+				err = __allocate_data_block(&dn,
+							    map->m_seg_type);
+				if (err)
+					goto sync_out;
+				if (flag == F2FS_GET_BLOCK_PRE_DIO)
+					file_need_truncate(inode);
+				set_inode_flag(inode, FI_APPEND_WRITE);
+				break;
+			default:
+				WARN_ON_ONCE(1);
+				err = -EIO;
+				goto sync_out;
+			}
+
+			blkaddr = dn.data_blkaddr;
+			if (is_hole)
+				map->m_flags |= F2FS_MAP_NEW;
+		} else if (is_hole) {
+			if (f2fs_compressed_file(inode) &&
+			    f2fs_sanity_check_cluster(&dn)) {
+				err = -EFSCORRUPTED;
+				f2fs_handle_error(sbi, ERROR_CORRUPTED_CLUSTER);
+				goto sync_out;
+			}
+
+			switch (flag) {
+			case F2FS_GET_BLOCK_PRECACHE:
+				goto sync_out;
+			case F2FS_GET_BLOCK_BMAP:
+				map->m_pblk = 0;
+				goto sync_out;
+			case F2FS_GET_BLOCK_FIEMAP:
+				if (blkaddr == NULL_ADDR) {
+					if (map->m_next_pgofs)
+						*map->m_next_pgofs = pgofs + 1;
+					goto sync_out;
+				}
+				break;
+			case F2FS_GET_BLOCK_DIO:
 				if (map->m_next_pgofs)
+					*map->m_next_pgofs = pgofs + 1;
+				break;
+			case F2FS_GET_BLOCK_IOMAP:
+				if (map->m_next_pgofs)
+					*map->m_next_pgofs = pgofs + 1;
+				break;
+			default:
+				/* for defragment case */
+				if (map->m_next_pgofs) /*还没设置f2fs_block_map中的next_pgofs的话 将其设置为+1*/
 					*map->m_next_pgofs = pgofs + 1;
 				goto sync_out;
 			}
-			break;
-		case F2FS_GET_BLOCK_DIO:
-			if (map->m_next_pgofs)
-				*map->m_next_pgofs = pgofs + 1;
-			break;
-		default:
-			/* for defragment case */
-			if (map->m_next_pgofs)
-				*map->m_next_pgofs = pgofs + 1;
-			goto sync_out;
 		}
-	}
-
-	if (flag == F2FS_GET_BLOCK_PRE_AIO)
-		goto skip;
-
-	if (map->m_multidev_dio)
-		bidx = f2fs_target_device_index(sbi, blkaddr);
-
-	if (map->m_len == 0) {
-		/* reserved delalloc block should be mapped for fiemap. */
-		if (blkaddr == NEW_ADDR)
-			map->m_flags |= F2FS_MAP_DELALLOC;
-		/* DIO READ and hole case, should not map the blocks. */
-		if (!(flag == F2FS_GET_BLOCK_DIO && is_hole && !map->m_may_create))
-			map->m_flags |= F2FS_MAP_MAPPED;
-
-		map->m_pblk = blkaddr;
-		map->m_len = 1;
+		if (flag == F2FS_GET_BLOCK_PRE_AIO)
+			goto skip;
 
 		if (map->m_multidev_dio)
-			map->m_bdev = FDEV(bidx).bdev;
-	} else if (map_is_mergeable(sbi, map, blkaddr, flag, bidx, ofs)) {
-		ofs++;
-		map->m_len++;
-	} else {
-		goto sync_out;
-	}
+			bidx = f2fs_target_device_index(sbi, blkaddr);
 
-skip:
-	dn.ofs_in_node++;
-	pgofs++;
+		if (map->m_len == 0) {
+			/* reserved delalloc block should be mapped for fiemap. */
+			if (blkaddr == NEW_ADDR)
+				map->m_flags |= F2FS_MAP_DELALLOC;
+			/* DIO READ and hole case, should not map the blocks.*/
+			if (!(flag == F2FS_GET_BLOCK_DIO && is_hole &&
+			      !map->m_may_create))
+				map->m_flags |= F2FS_MAP_MAPPED;
 
-	/* preallocate blocks in batch for one dnode page */
-	if (flag == F2FS_GET_BLOCK_PRE_AIO &&
-			(pgofs == end || dn.ofs_in_node == end_offset)) {
+			map->m_pblk = blkaddr;
+			map->m_len = 1;
 
-		dn.ofs_in_node = ofs_in_node;
-		err = f2fs_reserve_new_blocks(&dn, prealloc);
-		if (err)
-			goto sync_out;
-
-		map->m_len += dn.ofs_in_node - ofs_in_node;
-		if (prealloc && dn.ofs_in_node != last_ofs_in_node + 1) {
-			err = -ENOSPC;
+			if (map->m_multidev_dio)
+				map->m_bdev = FDEV(bidx).bdev;
+		} else if (map_is_mergeable(
+				   sbi, map, blkaddr, flag, bidx,
+				   ofs)) {
+			ofs++;
+			map->m_len++;
+		} else {
 			goto sync_out;
 		}
-		dn.ofs_in_node = end_offset;
-	}
 
-	if (flag == F2FS_GET_BLOCK_DIO && f2fs_lfs_mode(sbi) &&
-	    map->m_may_create) {
-		/* the next block to be allocated may not be contiguous. */
-		if (GET_SEGOFF_FROM_SEG0(sbi, blkaddr) % BLKS_PER_SEC(sbi) ==
-		    CAP_BLKS_PER_SEC(sbi) - 1)
+skip:
+		dn.ofs_in_node++;
+		pgofs++;
+
+		/* preallocate blocks in batch for one dnode page */
+		if (flag == F2FS_GET_BLOCK_PRE_AIO &&
+		    (pgofs == end || dn.ofs_in_node == end_offset)) {
+			dn.ofs_in_node = ofs_in_node;
+			err = f2fs_reserve_new_blocks(&dn, prealloc);
+			if (err)
+				goto sync_out;
+
+			map->m_len += dn.ofs_in_node - ofs_in_node;
+			/*Since we successfully reserved blocks, we can update the pblk
+			and mark it as mapped.
+			No need to perform inefficient look up in write_begin again */
+			map->m_pblk = dn.data_blkaddr; 
+			map->m_flags |= F2FS_MAP_MAPPED;
+			if (prealloc &&
+			    dn.ofs_in_node != last_ofs_in_node + 1) {
+				err = -ENOSPC;
+				goto sync_out;
+			}
+			dn.ofs_in_node = end_offset;
+		}
+
+		if (flag == F2FS_GET_BLOCK_DIO && f2fs_lfs_mode(sbi) &&
+		    map->m_may_create) {
+			/* the next block to be allocated may not be contiguous. */
+			if (GET_SEGOFF_FROM_SEG0(sbi, blkaddr) %
+				    BLKS_PER_SEC(sbi) ==
+			    CAP_BLKS_PER_SEC(sbi) - 1)
+				goto sync_out;
+		}
+
+		if (pgofs >= end)
 			goto sync_out;
-	}
-
-	if (pgofs >= end)
-		goto sync_out;
-	else if (dn.ofs_in_node < end_offset)
-		goto next_block;
-
-	if (flag == F2FS_GET_BLOCK_PRECACHE) {
+	} while (dn.ofs_in_node < end_offset);
+	if (flag == F2FS_GET_BLOCK_PRECACHE|| flag == F2FS_GET_BLOCK_IOMAP) {
 		if (map->m_flags & F2FS_MAP_MAPPED) {
 			unsigned int ofs = start_pgofs - map->m_lblk;
 
@@ -1794,7 +1812,30 @@ out:
 	trace_f2fs_map_blocks(inode, map, flag, err);
 	return err;
 }
-
+int f2fs_map_blocks_iomap(struct inode *inode, block_t start, block_t len,
+			  struct f2fs_map_blocks *map)
+{
+	int err = 0;
+	map->m_lblk = start; // Logical block number for the start pos
+	map->m_len = len; // Length in blocks
+	map->m_may_create = false;
+	map->m_seg_type =
+		f2fs_rw_hint_to_seg_type(F2FS_I_SB(inode), inode->i_write_hint);
+	err = f2fs_map_blocks(inode, map, F2FS_GET_BLOCK_IOMAP);
+	return err;
+}
+int f2fs_map_blocks_preallocate(struct inode *inode, block_t start, block_t len,
+				struct f2fs_map_blocks *map)
+{
+	int err = 0;
+	map->m_lblk = start;
+	map->m_len = len; // Length in blocks
+	map->m_may_create = true;
+	map->m_seg_type =
+		f2fs_rw_hint_to_seg_type(F2FS_I_SB(inode), inode->i_write_hint);
+	err = f2fs_map_blocks(inode, map, F2FS_GET_BLOCK_PRE_AIO);
+	return err;
+}
 bool f2fs_overwrite_io(struct inode *inode, loff_t pos, size_t len)
 {
 	struct f2fs_map_blocks map;
@@ -2639,7 +2680,6 @@ static inline bool need_inplace_update(struct f2fs_io_info *fio)
 
 	return f2fs_should_update_inplace(inode, fio);
 }
-
 int f2fs_do_write_data_page(struct f2fs_io_info *fio)
 {
 	struct folio *folio = page_folio(fio->page);
@@ -2657,14 +2697,14 @@ int f2fs_do_write_data_page(struct f2fs_io_info *fio)
 		set_new_dnode(&dn, F2FS_I(inode)->cow_inode, NULL, NULL, 0);
 	else
 		set_new_dnode(&dn, inode, NULL, NULL, 0);
-
+	
 	if (need_inplace_update(fio) &&
-	    f2fs_lookup_read_extent_cache_block(inode, folio->index,
+	    f2fs_lookup_read_extent_cache_block(inode, folio->index+folio_page_idx(folio,fio->page),
 						&fio->old_blkaddr)) {
 		if (!f2fs_is_valid_blkaddr(fio->sbi, fio->old_blkaddr,
 						DATA_GENERIC_ENHANCE))
 			return -EFSCORRUPTED;
-
+		
 		ipu_force = true;
 		fio->need_lock = LOCK_DONE;
 		goto got_it;
@@ -2674,7 +2714,7 @@ int f2fs_do_write_data_page(struct f2fs_io_info *fio)
 	if (fio->need_lock == LOCK_REQ && !f2fs_trylock_op(fio->sbi))
 		return -EAGAIN;
 
-	err = f2fs_get_dnode_of_data(&dn, folio->index, LOOKUP_NODE);
+	err = f2fs_get_dnode_of_data(&dn, folio->index+folio_page_idx(folio,fio->page), LOOKUP_NODE);
 	if (err)
 		goto out;
 
@@ -2708,8 +2748,9 @@ got_it:
 		err = f2fs_encrypt_one_page(fio);
 		if (err)
 			goto out_writepage;
-
-		folio_start_writeback(folio);
+		
+		if(!folio_test_writeback(folio))
+			folio_start_writeback(folio);
 		f2fs_put_dnode(&dn);
 		if (fio->need_lock == LOCK_REQ)
 			f2fs_unlock_op(fio->sbi);
@@ -2742,9 +2783,12 @@ got_it:
 	err = f2fs_encrypt_one_page(fio);
 	if (err)
 		goto out_writepage;
-
-	folio_start_writeback(folio);
-
+	/*when called from write_cache_folios
+	folio already set writeback flag*/
+	if(!folio_test_writeback(folio))
+	{
+		folio_start_writeback(folio);
+	}
 	if (fio->compr_blocks && fio->old_blkaddr == COMPRESS_ADDR)
 		f2fs_i_compr_blocks_update(inode, fio->compr_blocks - 1, false);
 
@@ -3746,7 +3790,15 @@ void f2fs_invalidate_folio(struct folio *folio, size_t offset, size_t length)
 			f2fs_remove_dirty_inode(inode);
 		}
 	}
-	clear_page_private_all(&folio->page);
+	if (offset == 0 && length == folio_size(folio)) {
+		WARN_ON_ONCE(folio_test_writeback(folio));
+		folio_cancel_dirty(folio);
+		struct f2fs_iomap_folio_state* fifs= folio->private;
+	if (fifs) {
+		f2fs_ifs_free(folio);
+	}
+	}
+	
 }
 
 bool f2fs_release_folio(struct folio *folio, gfp_t wait)
@@ -3754,8 +3806,10 @@ bool f2fs_release_folio(struct folio *folio, gfp_t wait)
 	/* If this is dirty folio, keep private data */
 	if (folio_test_dirty(folio))
 		return false;
-
-	clear_page_private_all(&folio->page);
+	struct f2fs_iomap_folio_state* fifs= folio->private;
+	if (fifs) {
+		f2fs_ifs_free(folio);
+	}
 	return true;
 }
 
@@ -4194,9 +4248,6 @@ static int f2fs_iomap_begin(struct inode *inode, loff_t offset, loff_t length,
 	err = f2fs_map_blocks(inode, &map, F2FS_GET_BLOCK_DIO);
 	if (err)
 		return err;
-
-	iomap->offset = F2FS_BLK_TO_BYTES(map.m_lblk);
-
 	/*
 	 * When inline encryption is enabled, sometimes I/O to an encrypted file
 	 * has to be broken up to guarantee DUN contiguity.  Handle this by
@@ -4211,6 +4262,13 @@ static int f2fs_iomap_begin(struct inode *inode, loff_t offset, loff_t length,
 	if (WARN_ON_ONCE(map.m_pblk == COMPRESS_ADDR))
 		return -EINVAL;
 
+	f2fs_set_iomap(map,iomap,inode);
+
+	return 0;
+}
+void f2fs_set_iomap(struct inode*inode,struct f2fs_map_blocks*map,struct iomap*iomap)
+{
+	iomap->offset = F2FS_BLK_TO_BYTES(map.m_lblk);
 	if (map.m_flags & F2FS_MAP_MAPPED) {
 		if (WARN_ON_ONCE(map.m_pblk == NEW_ADDR))
 			return -EINVAL;
@@ -4242,10 +4300,202 @@ static int f2fs_iomap_begin(struct inode *inode, loff_t offset, loff_t length,
 	if ((inode->i_state & I_DIRTY_DATASYNC) ||
 	    offset + length > i_size_read(inode))
 		iomap->flags |= IOMAP_F_DIRTY;
-
-	return 0;
 }
-
 const struct iomap_ops f2fs_iomap_ops = {
 	.iomap_begin	= f2fs_iomap_begin,
 };
+
+static int
+f2fs_buffered_read_iomap_begin(struct inode *inode, loff_t offset,
+			       loff_t length, unsigned int flags,
+			       struct iomap *iomap, struct iomap *srcmap)
+{
+	pgoff_t next_pgofs = 0;
+	int err;
+	struct f2fs_map_blocks map = {};
+	map.m_lblk = F2FS_BYTES_TO_BLK(offset); /*起始逻辑块号*/
+	map.m_len = F2FS_BYTES_TO_BLK(offset + length - 1) - map.m_lblk + 1;
+	map.m_next_pgofs = &next_pgofs;
+	map.m_seg_type =
+		f2fs_rw_hint_to_seg_type(F2FS_I_SB(inode), inode->i_write_hint);
+	map.m_may_create = false;
+	struct extent_info ei = {};
+	bool use_extent = !is_inode_flag_set(inode, FI_NO_EXTENT);
+	if (is_sbi_flag_set(F2FS_I_SB(inode), SBI_IS_SHUTDOWN))
+		return -EIO;
+	/*
+	* If the blocks being overwritten are already allocated,
+	* f2fs_map_lock and f2fs_balance_fs are not necessary.
+	*/
+	if (flags & IOMAP_WRITE)
+		return -EINVAL;
+	if ((map.m_len >= F2FS_MIN_EXTENT_LEN ||
+	     f2fs_lookup_read_extent_cache(inode, map.m_lblk - 1, &ei)) &&
+	    use_extent) {
+		err = f2fs_map_blocks(inode, &map, F2FS_GET_BLOCK_IOMAP);
+		if (err)
+			return err;
+	} else {
+		err = f2fs_map_blocks(inode, &map, F2FS_GET_BLOCK_DEFAULT);
+		if (err)
+			return err;
+	}
+	if (WARN_ON_ONCE(map.m_pblk == COMPRESS_ADDR))
+		return -EINVAL;
+
+	f2fs_set_iomap(inode,map,iomap);
+
+	return 0;
+}
+const struct iomap_ops f2fs_buffered_read_iomap_ops = {
+	.iomap_begin = f2fs_buffered_read_iomap_begin,
+};
+
+ 
+static void f2fs_iomap_readahead(struct readahead_control *rac)
+{
+	struct inode *inode = rac->mapping->host;
+
+	if (!f2fs_is_compress_backend_ready(inode))
+		return;
+
+	/* If the file has inline data, skip readahead */
+	if (f2fs_has_inline_data(inode))
+		return;
+	iomap_readahead(rac, &f2fs_buffered_read_iomap_ops);
+}
+ 
+static int f2fs_buffered_write_iomap_begin(struct inode *inode, loff_t pos, loff_t length,
+				unsigned flags, struct iomap *iomap,
+				struct iomap *srcmap)
+{
+	struct f2fs_sb_info *sbi = F2FS_I_SB(inode);
+	struct f2fs_map_blocks map = {};
+	struct folio *ifolio = NULL;
+	int err = 0;
+	iomap->offset = pos; 
+	iomap->bdev = sbi->sb->s_bdev; // Default block device
+	iomap->folio_ops = &f2fs_iomap_folio_ops;
+	if (f2fs_has_inline_data(inode)) {
+		// If the write starts and fits entirely within the inline area
+		if (pos + length <= MAX_INLINE_DATA(inode)) {
+			ifolio = f2fs_get_inode_folio(sbi, inode->i_ino);
+			if (IS_ERR(ifolio))
+				return PTR_ERR(ifolio);
+
+			set_inode_flag(inode, FI_DATA_EXIST);
+			f2fs_iomap_prepare_read_inline(inode, ifolio, iomap,
+						       pos, length);
+			if (inode->i_nlink)
+				f2fs_set_folio_private_inline(
+					&ifolio->page); // Use f2fs helper
+
+			f2fs_folio_put(ifolio, 1); // Release folio reference
+			goto out; // Success for inline case
+		} 
+	}
+	block_t start_blk = F2FS_BYTES_TO_BLK(pos);
+	block_t len_blks = F2FS_BYTES_TO_BLK(pos + length - 1) - start_blk + 1;
+	err = f2fs_map_blocks_iomap(inode, start_blk, len_blks, &map);
+	if (map.m_pblk == NULL_ADDR) {
+		err = f2fs_map_blocks_preallocate(inode, map.m_lblk, len_blks,
+						  &map);
+		if (err)
+			return err;
+	}
+	if (WARN_ON_ONCE(map.m_pblk == COMPRESS_ADDR))
+		return -EIO; // Should not happen for buffered write prep
+	f2fs_set_iomap(inode,map,iomap);
+out:
+	return err;
+}
+static int f2fs_buffered_write_atomic_iomap_begin(struct inode *inode,
+						  loff_t pos, loff_t length,
+						  unsigned flags,
+						  struct iomap *iomap,
+						  struct iomap *srcmap)
+{
+	struct inode *cow_inode = F2FS_I(inode)->cow_inode;
+	struct f2fs_sb_info *sbi = F2FS_I_SB(inode);
+	struct f2fs_map_blocks map = {};
+	int err = 0;
+	iomap->offset = pos; 
+	iomap->bdev = sbi->sb->s_bdev; 
+	iomap->folio_ops =
+		&f2fs_iomap_folio_ops; 
+	block_t start_blk = F2FS_BYTES_TO_BLK(pos);
+	block_t len_blks = F2FS_BYTES_TO_BLK(pos + length - 1) - start_blk + 1;
+	err = f2fs_map_blocks_iomap(cow_inode, start_blk, len_blks, &map);
+	if (err &&
+	    err != -ENOSPC) // Allow -ENOSPC as some blocks might be mapped
+		return err;
+	if (map.m_pblk == NULL_ADDR &&
+	    is_inode_flag_set(inode, FI_ATOMIC_REPLACE)) {
+		err = f2fs_map_blocks_preallocate(cow_inode, map.m_lblk,
+						  map.m_len, &map);
+		if (err && err != -ENOSPC)
+			return err;
+		inc_atomic_write_cnt(inode);
+		goto out;
+	} else if (map.m_pblk != NULL_ADDR) {
+		return 0;
+	}
+	err = f2fs_map_blocks_iomap(inode, start_blk, len_blks, &map);
+	if (err &&
+	    err != -ENOSPC) // Allow -ENOSPC as some blocks might be mapped
+		return err;
+out:
+	if (WARN_ON_ONCE(map.m_pblk == COMPRESS_ADDR))
+		return -EIO; // Should not happen for buffered write prep
+
+	f2fs_set_iomap(inode,map,iomap);
+	return 0;
+}
+static int f2fs_buffered_write_iomap_end(struct inode *inode, loff_t pos,
+        loff_t length, ssize_t written, unsigned flags, struct iomap *iomap)
+{
+    return written;
+}
+const struct iomap_ops f2fs_buffered_write_iomap_ops = {
+	.iomap_begin = f2fs_buffered_write_iomap_begin,
+	.iomap_end = f2fs_buffered_write_iomap_end,
+};
+const struct iomap_ops f2fs_buffered_write_atomic_iomap_ops = {
+	.iomap_begin = f2fs_buffered_write_atomic_iomap_begin,
+};
+const struct address_space_operations f2fs_iomap_aops = {
+	.read_folio = f2fs_read_data_folio,
+	.readahead = f2fs_iomap_readahead,
+	.write_begin = f2fs_write_begin,
+	.write_end = f2fs_write_end,
+	.writepages		= f2fs_write_data_pages,
+	.dirty_folio		= f2fs_dirty_data_folio,
+	.invalidate_folio	= f2fs_invalidate_folio,
+	.release_folio		= f2fs_release_folio,
+	.migrate_folio		= filemap_migrate_folio,
+	.is_partially_uptodate  = iomap_is_partially_uptodate,
+	.error_remove_page	= generic_error_remove_page,
+};
+const struct iomap_folio_ops f2fs_iomap_folio_ops = {
+	.put_folio = f2fs_iomap_put_folio,
+};
+void f2fs_iomap_put_folio(struct inode *inode, loff_t pos, unsigned copied,
+			  struct folio *folio)
+{
+	if (!copied)
+		goto unlock_out;
+	if (f2fs_is_atomic_file(inode))
+		f2fs_set_folio_private_atomic(folio);
+
+	if (pos + copied > i_size_read(inode) &&
+	    !f2fs_verity_in_progress(inode)) {
+		f2fs_i_size_write(inode, pos + copied);
+		if (f2fs_is_atomic_file(inode))
+			f2fs_i_size_write(F2FS_I(inode)->cow_inode,
+					  pos + copied);
+	}
+unlock_out:
+	folio_unlock(folio);
+	folio_put(folio);
+	f2fs_update_time(F2FS_I_SB(inode), REQ_TIME);
+}

--- a/fs/f2fs/f2fs.h
+++ b/fs/f2fs/f2fs.h
@@ -27,9 +27,9 @@
 
 #include <linux/fscrypt.h>
 #include <linux/fsverity.h>
-
+#include <linux/iomap.h>
 struct pagevec;
-
+struct iomap_folio_state;
 #ifdef CONFIG_F2FS_CHECK_FS
 #define f2fs_bug_on(sbi, condition)	BUG_ON(condition)
 #else
@@ -743,6 +743,7 @@ enum {
 	F2FS_GET_BLOCK_PRE_DIO,
 	F2FS_GET_BLOCK_PRE_AIO,
 	F2FS_GET_BLOCK_PRECACHE,
+	F2FS_GET_BLOCK_IOMAP,
 };
 
 /*
@@ -1462,6 +1463,7 @@ enum {
 	PAGE_PRIVATE_INLINE_INODE,		/* inode page contains inline data */
 	PAGE_PRIVATE_REF_RESOURCE,		/* dirty page has referenced resources */
 	PAGE_PRIVATE_ATOMIC_WRITE,		/* data page from atomic write path */
+	PAGE_PRIVATE_DEFERRED_UNLOCK,  /* deffered unlock in write_cache_folios for cross cluster folio*/
 	PAGE_PRIVATE_MAX
 };
 
@@ -2561,7 +2563,17 @@ static inline void inc_page_count(struct f2fs_sb_info *sbi, int count_type)
 			count_type == F2FS_DIRTY_IMETA)
 		set_sbi_flag(sbi, SBI_IS_DIRTY);
 }
+static inline void inc_page_count_multiple(struct f2fs_sb_info *sbi, int count_type,int npages)
+{
+	atomic_add(npages,&sbi->nr_pages[count_type]);
 
+	if (count_type == F2FS_DIRTY_DENTS ||
+			count_type == F2FS_DIRTY_NODES ||
+			count_type == F2FS_DIRTY_META ||
+			count_type == F2FS_DIRTY_QDATA ||
+			count_type == F2FS_DIRTY_IMETA)
+		set_sbi_flag(sbi, SBI_IS_DIRTY);
+}
 static inline void inode_inc_dirty_pages(struct inode *inode)
 {
 	atomic_inc(&F2FS_I(inode)->dirty_pages);
@@ -3621,7 +3633,7 @@ void f2fs_update_inode_page(struct inode *inode);
 int f2fs_write_inode(struct inode *inode, struct writeback_control *wbc);
 void f2fs_evict_inode(struct inode *inode);
 void f2fs_handle_failed_inode(struct inode *inode);
-
+bool f2fs_should_use_buffered_iomap(struct inode *inode);
 /*
  * namei.c
  */
@@ -3973,6 +3985,10 @@ struct folio *f2fs_get_new_data_folio(struct inode *inode,
 			struct folio *ifolio, pgoff_t index, bool new_i_size);
 int f2fs_do_write_data_page(struct f2fs_io_info *fio);
 int f2fs_map_blocks(struct inode *inode, struct f2fs_map_blocks *map, int flag);
+int f2fs_map_blocks_iomap(struct inode*inode,block_t start, block_t len,
+	struct f2fs_map_blocks *map);
+int f2fs_map_blocks_preallocate(struct inode *inode,block_t start, block_t len,
+	struct f2fs_map_blocks *map);
 int f2fs_fiemap(struct inode *inode, struct fiemap_extent_info *fieinfo,
 			u64 start, u64 len);
 int f2fs_encrypt_one_page(struct f2fs_io_info *fio);
@@ -3984,6 +4000,7 @@ int f2fs_write_single_data_page(struct folio *folio, int *submitted,
 				enum iostat_type io_type,
 				int compr_blocks, bool allow_balance);
 void f2fs_write_failed(struct inode *inode, loff_t to);
+void f2fs_set_iomap(struct inode*inode,struct f2fs_map_blocks*map,struct iomap*iomap);
 void f2fs_invalidate_folio(struct folio *folio, size_t offset, size_t length);
 bool f2fs_release_folio(struct folio *folio, gfp_t wait);
 bool f2fs_overwrite_io(struct inode *inode, loff_t pos, size_t len);
@@ -4276,6 +4293,7 @@ extern const struct file_operations f2fs_dir_operations;
 extern const struct file_operations f2fs_file_operations;
 extern const struct inode_operations f2fs_file_inode_operations;
 extern const struct address_space_operations f2fs_dblock_aops;
+extern const struct address_space_operations f2fs_iomap_aops;
 extern const struct address_space_operations f2fs_node_aops;
 extern const struct address_space_operations f2fs_meta_aops;
 extern const struct inode_operations f2fs_dir_inode_operations;
@@ -4314,7 +4332,8 @@ int f2fs_read_inline_dir(struct file *file, struct dir_context *ctx,
 int f2fs_inline_data_fiemap(struct inode *inode,
 			struct fiemap_extent_info *fieinfo,
 			__u64 start, __u64 len);
-
+void f2fs_iomap_prepare_read_inline(struct inode* inode,struct folio* ifolio,struct iomap* iomap,
+	loff_t pos,loff_t length);
 /*
  * shrinker.c
  */
@@ -4421,9 +4440,10 @@ enum cluster_check_type {
 	CLUSTER_RAW_BLKS    /* return # of raw blocks in a cluster */
 };
 bool f2fs_is_compressed_page(struct page *page);
+bool f2fs_is_compressed_folio(struct folio *folio);
 struct folio *f2fs_compress_control_folio(struct folio *folio);
 int f2fs_prepare_compress_overwrite(struct inode *inode,
-			struct page **pagep, pgoff_t index, void **fsdata);
+			struct page **pagep, pgoff_t index, void **fsdata,fgf_t fgp_flags);
 bool f2fs_compress_write_end(struct inode *inode, void *fsdata,
 					pgoff_t index, unsigned copied);
 int f2fs_truncate_partial_cluster(struct inode *inode, u64 from, bool lock);

--- a/fs/f2fs/f2fs.h
+++ b/fs/f2fs/f2fs.h
@@ -1577,7 +1577,25 @@ struct decompress_io_ctx {
 	struct work_struct verity_work;	/* work to verify the decompressed pages */
 	struct work_struct free_work;	/* work for late free this structure itself */
 };
-
+struct f2fs_readpage_ctx {
+	struct folio		*cur_folio;
+	bool			cur_folio_in_bio;
+	struct bio		*bio;
+	struct readahead_control *rac;
+#ifdef CONFIG_F2FS_FS_COMPRESSION
+	struct compress_ctx cc;
+	bool cur_folio_in_compress_ctx;
+#endif
+};
+struct f2fs_compressed_pblks_info
+{
+	bool is_from_extent;
+	unsigned int num_pblks;
+	union{
+		struct extent_info ei;
+		struct dnode_of_data dn;
+	}blk_info;
+};
 #define NULL_CLUSTER			((unsigned int)(~0))
 #define MIN_COMPRESS_LOG_SIZE		2
 #define MAX_COMPRESS_LOG_SIZE		8
@@ -3999,6 +4017,17 @@ int f2fs_write_single_data_page(struct folio *folio, int *submitted,
 				struct writeback_control *wbc,
 				enum iostat_type io_type,
 				int compr_blocks, bool allow_balance);
+int f2fs_write_single_data_folio(struct folio *folio, int *submitted_pages_count,
+				struct bio **bio_ptr, sector_t *last_block_ptr,
+				struct writeback_control *wbc,
+				enum iostat_type io_type,int compr_blocks,
+				bool from_compress, bool is_reclaim,
+				u64 start, u64 end);
+int f2fs_write_split_folio_range(struct address_space *mapping,
+					struct writeback_control *wbc,
+					enum iostat_type io_type,
+					pgoff_t start_index,
+					pgoff_t end_index,struct folio *first_folio);
 void f2fs_write_failed(struct inode *inode, loff_t to);
 void f2fs_set_iomap(struct inode*inode,struct f2fs_map_blocks*map,struct iomap*iomap);
 void f2fs_invalidate_folio(struct folio *folio, size_t offset, size_t length);
@@ -4009,8 +4038,39 @@ int f2fs_init_post_read_processing(void);
 void f2fs_destroy_post_read_processing(void);
 int f2fs_init_post_read_wq(struct f2fs_sb_info *sbi);
 void f2fs_destroy_post_read_wq(struct f2fs_sb_info *sbi);
+void f2fs_iomap_put_folio(struct inode *inode, loff_t pos, unsigned copied,struct folio *folio);
+struct folio* f2fs_iomap_get_folio(struct iomap_iter *iter, loff_t pos,
+			unsigned len);
+void f2fs_init_readpage_ctx(struct f2fs_readpage_ctx *ctx,struct readahead_control *rac);
+int f2fs_compress_iomap_readahead(struct inode *inode, struct readahead_control *rac);
+int f2fs_do_read_single_folio_iomap(struct iomap_iter *iter,struct f2fs_readpage_ctx *ctx, loff_t pos,loff_t plen, loff_t poff);	
+int f2fs_do_read_multi_folios(struct f2fs_readpage_ctx* ctx, loff_t pos,loff_t plen);
+int do_read_multi_folios(struct compress_ctx*cc, struct folio *folio, loff_t pos,
+				  loff_t plen, struct bio** bio_ret,
+				  struct readahead_control *rac,bool for_write);
+void f2fs_iomap_finish_folio_read(struct folio *folio, size_t off,size_t len, int error);
 extern const struct iomap_ops f2fs_iomap_ops;
-
+extern const struct iomap_folio_ops f2fs_iomap_folio_ops;
+extern const struct iomap_ops f2fs_buffered_read_iomap_ops;
+extern const struct iomap_ops f2fs_buffered_write_iomap_ops;
+extern const struct iomap_ops f2fs_buffered_write_atomic_iomap_ops;
+extern void iomap_adjust_read_range(struct inode *inode, struct folio *folio,
+		loff_t *pos, loff_t length, size_t *offp, size_t *lenp);
+extern bool iomap_block_needs_zeroing(const struct iomap_iter *iter,
+		loff_t pos);
+extern bool iomap_writepage_handle_eof(struct folio *folio, struct inode *inode,
+		u64 *end_pos);		
+extern void iomap_set_range_uptodate(struct folio *folio, size_t off,
+		size_t len);
+extern void iomap_set_range_dirty(struct folio *folio, size_t off, size_t len);
+extern void iomap_clear_range_dirty(struct folio *folio, size_t off, size_t len);
+extern unsigned iomap_find_dirty_range(struct folio *folio, u64 *range_start,
+		u64 range_end);
+extern int iomap_iter_advance(struct iomap_iter *iter, u64 *count);
+extern void ifs_set_range_dirty(struct folio *folio,
+		struct iomap_folio_state *ifs, size_t off, size_t len);
+extern bool ifs_set_range_uptodate(struct folio *folio,
+		struct iomap_folio_state *ifs, size_t off, size_t len);
 /*
  * gc.c
  */
@@ -4456,6 +4516,8 @@ void f2fs_decompress_cluster(struct decompress_io_ctx *dic, bool in_task);
 void f2fs_end_read_compressed_page(struct page *page, bool failed,
 				block_t blkaddr, bool in_task);
 bool f2fs_cluster_is_empty(struct compress_ctx *cc);
+bool f2fs_cluster_is_full(struct compress_ctx *cc);
+bool f2fs_cluster_is_partial_full(struct compress_ctx *cc);
 bool f2fs_cluster_can_merge_page(struct compress_ctx *cc, pgoff_t index);
 bool f2fs_all_cluster_page_ready(struct compress_ctx *cc, struct page **pages,
 				int index, int nr_pages, bool uptodate);
@@ -4473,6 +4535,8 @@ void f2fs_update_read_extent_tree_range_compressed(struct inode *inode,
 int f2fs_read_multi_pages(struct compress_ctx *cc, struct bio **bio_ret,
 				unsigned nr_pages, sector_t *last_block_in_bio,
 				struct readahead_control *rac, bool for_write);
+int f2fs_read_multi_folios(struct compress_ctx *cc, struct bio **bio_ret,
+			   struct readahead_control *rac, bool for_write);
 struct decompress_io_ctx *f2fs_alloc_dic(struct compress_ctx *cc);
 void f2fs_decompress_end_io(struct decompress_io_ctx *dic, bool failed,
 				bool in_task);
@@ -4496,6 +4560,14 @@ void f2fs_cache_compressed_page(struct f2fs_sb_info *sbi, struct page *page,
 bool f2fs_load_compressed_folio(struct f2fs_sb_info *sbi, struct folio *folio,
 								block_t blkaddr);
 void f2fs_invalidate_compress_pages(struct f2fs_sb_info *sbi, nid_t ino);
+void f2fs_compress_ctx_add_folio(struct compress_ctx *cc, struct folio *folio,loff_t pos,loff_t rlen);
+int f2fs_wait_cluster_uptodate(struct inode*inode,pgoff_t start_check_idx,unsigned int cluster_size);
+pgoff_t start_idx_of_cluster(struct compress_ctx *cc);
+pgoff_t cluster_idx(struct compress_ctx *cc, pgoff_t index);
+pgoff_t end_idx_of_cluster(struct compress_ctx *cc, pgoff_t index);
+pgoff_t cluster_i_idx(struct inode*inode,pgoff_t index);
+pgoff_t i_end_idx_of_cluster(struct inode*inode,pgoff_t index);
+unsigned int offset_i_in_cluster(struct inode*inode,pgoff_t index);
 #define inc_compr_inode_stat(inode)					\
 	do {								\
 		struct f2fs_sb_info *sbi = F2FS_I_SB(inode);		\

--- a/fs/f2fs/f2fs_ifs.c
+++ b/fs/f2fs/f2fs_ifs.c
@@ -144,6 +144,23 @@ struct f2fs_iomap_folio_state *f2fs_folio_get_private(struct folio *folio)
     
     return NULL;
 }
+unsigned f2fs_iomap_find_dirty_range(struct folio *folio, u64 *range_start,
+		u64 range_end)
+{
+	struct inode* inode=folio->mapping->host;
+	
+	if(folio_order(folio) == 0) 
+	 	return range_end-*range_start;
+	if(f2fs_compressed_file(inode))
+	{	
+		/*clamp range end to a cluster's size*/
+		int a=*range_start>>PAGE_SHIFT;
+		int b=cluster_i_idx(inode, a)<<F2FS_I(inode)->i_cluster_size;
+		int c=(F2FS_I(inode)->i_cluster_size - 1);
+		range_end=min(range_end,(i_end_idx_of_cluster(inode,*range_start>>PAGE_SHIFT)+1) << PAGE_SHIFT);
+	}
+	return iomap_find_dirty_range(folio, range_start, range_end);
+}
 void f2fs_ifs_clear_range_uptodate(struct folio *folio, struct f2fs_iomap_folio_state*fifs,size_t off, size_t len)
 {
 	struct inode *inode = folio->mapping->host;

--- a/fs/f2fs/f2fs_ifs.c
+++ b/fs/f2fs/f2fs_ifs.c
@@ -1,0 +1,259 @@
+//f2fs_ifs.c
+#include <linux/fs.h>
+#include <linux/f2fs_fs.h>
+#include <linux/mm.h>
+#include <linux/iomap.h>
+#include <linux/slab.h>
+#include <linux/sched.h> // For cond_resched()
+#include "f2fs.h"
+#include "f2fs_ifs.h" 
+struct f2fs_iomap_folio_state *f2fs_ifs_alloc(struct folio *folio, gfp_t gfp,bool force_alloc)
+{
+	struct inode* inode= folio->mapping->host;
+	size_t alloc_size=0;
+	if (folio_order(folio) == 0) {
+		if(!force_alloc)
+		{
+			WARN_ON_ONCE(1); 
+			return NULL;
+		}
+		else
+		{/* GC can store private flag in 0 order folio's folio->private
+			causes iomap buffered write mistakenly interpret as a pointer
+			we add a bool force_alloc to deal with this case
+		*/
+			struct f2fs_iomap_folio_state *fifs;
+			alloc_size = sizeof(*fifs) + 2*sizeof(unsigned long);
+			fifs = kmalloc(alloc_size, gfp); 
+			if (!fifs)
+				return NULL;
+			spin_lock_init(&fifs->state_lock);
+			WRITE_ONCE(fifs->read_bytes_pending, F2FS_IFS_MAGIC);
+        	atomic_set(&fifs->write_bytes_pending, 0); 
+			unsigned int nr_blocks = i_blocks_per_folio(inode, folio);
+			if (folio_test_uptodate(folio))
+				bitmap_set(fifs->state, 0, nr_blocks);
+			if (folio_test_dirty(folio))
+				(fifs->state, nr_blocks, nr_blocks);
+			*f2fs_ifs_private_flags_ptr(fifs, folio) = 0; 
+			folio_attach_private(folio, fifs);
+		}
+	}
+	struct f2fs_iomap_folio_state *fifs;
+	void *old_private;
+	size_t iomap_longs;
+	size_t total_longs;	
+	WARN_ON_ONCE(!inode); // Should have an inode
+
+	old_private = folio_get_private(folio);
+
+	if (old_private) {
+		// Check if it's already our type using the magic number directly
+		if (READ_ONCE(((struct f2fs_iomap_folio_state *)old_private)->read_bytes_pending) == F2FS_IFS_MAGIC) {
+			return (struct f2fs_iomap_folio_state *)old_private; // Already ours
+		} else {
+			// Non-NULL, not ours -> Allocate, Copy, Replace path
+			total_longs = f2fs_ifs_total_longs(folio);
+			alloc_size = sizeof(*fifs) + total_longs * sizeof(unsigned long);
+
+			fifs = kmalloc(alloc_size, gfp); 
+			if (!fifs)
+				return NULL;
+
+			spin_lock_init(&fifs->state_lock);
+			*f2fs_ifs_private_flags_ptr(fifs, folio) = 0; 
+			// Copy data from the presumed iomap_folio_state (old_private)
+			ifs_to_f2fs_ifs(old_private, fifs, folio);
+			WRITE_ONCE(fifs->read_bytes_pending, F2FS_IFS_MAGIC);
+            atomic_set(f2fs_ifs_dirty_bytes_pending_ptr(fifs, folio), 0);
+			folio_change_private(folio, fifs);
+			kfree(old_private); 
+			return fifs;
+		}
+	} else {
+		iomap_longs = f2fs_ifs_iomap_longs(folio);
+		total_longs = iomap_longs + 1;
+		alloc_size = sizeof(*fifs) + total_longs * sizeof(unsigned long);
+
+		fifs = kzalloc(alloc_size, gfp);
+		if (!fifs)
+			return NULL;
+
+		spin_lock_init(&fifs->state_lock);
+
+		unsigned int nr_blocks = i_blocks_per_folio(inode, folio);
+		
+		if (folio_test_uptodate(folio))
+			bitmap_set(fifs->state, 0, nr_blocks);
+		if (folio_test_dirty(folio))
+			bitmap_set(fifs->state, nr_blocks, nr_blocks);		
+		WRITE_ONCE(fifs->read_bytes_pending, F2FS_IFS_MAGIC);
+        atomic_set(&fifs->write_bytes_pending, 0); 
+        atomic_set(f2fs_ifs_dirty_bytes_pending_ptr(fifs, folio), 0);
+		folio_attach_private(folio, fifs);
+		return fifs;
+	}
+}
+void f2fs_ifs_free(struct folio *folio)
+{
+	struct f2fs_iomap_folio_state*fifs;
+	
+	if (!folio_test_private(folio))
+		return;
+		
+	// Check if it's using direct flags
+	if (test_bit(PAGE_PRIVATE_NOT_POINTER, (unsigned long *)&folio->private)) {
+		folio_detach_private(folio);
+		return;
+	}
+	
+	fifs = folio_detach_private(folio);
+	if (!fifs)
+		return; 
+	
+	if(is_f2fs_ifs(folio))
+	{	
+		WARN_ON_ONCE(READ_ONCE(fifs->read_bytes_pending) != F2FS_IFS_MAGIC);
+		WARN_ON_ONCE(atomic_read(&fifs->write_bytes_pending));
+	}
+	else
+	{
+		WARN_ON_ONCE(READ_ONCE(fifs->read_bytes_pending) != 0);
+		WARN_ON_ONCE(atomic_read(&fifs->write_bytes_pending));
+	}
+	
+	kfree(fifs);
+}
+struct f2fs_iomap_folio_state *f2fs_folio_get_private(struct folio *folio)
+{
+    if (!folio_test_private(folio))
+        return NULL;
+        
+    // 检查是否为标志位使用
+    if (test_bit(PAGE_PRIVATE_NOT_POINTER, (unsigned long *)&folio->private))
+        return NULL;
+        
+    void *private_data = folio->private;
+    if (!private_data)
+        return NULL;
+        
+    // 安全地检查 magic
+    struct f2fs_iomap_folio_state *fifs = private_data;
+    if (READ_ONCE(fifs->read_bytes_pending) == F2FS_IFS_MAGIC)
+        return fifs;
+    
+    return NULL;
+}
+void f2fs_ifs_clear_range_uptodate(struct folio *folio, struct f2fs_iomap_folio_state*fifs,size_t off, size_t len)
+{
+	struct inode *inode = folio->mapping->host;
+	unsigned int first_blk = (off >> inode->i_blkbits);
+	unsigned int last_blk = (off + len - 1) >> inode->i_blkbits;
+	unsigned int nr_blks = last_blk - first_blk + 1;
+	unsigned long flags;
+	spin_lock_irqsave(&fifs->state_lock, flags);
+	bitmap_clear(fifs->state, first_blk, nr_blks);
+	spin_unlock_irqrestore(&fifs->state_lock, flags);
+}
+inline unsigned long f2fs_get_folio_private_data(struct folio *folio)
+{
+	struct f2fs_iomap_folio_state *fifs = 
+		(struct f2fs_iomap_folio_state *)folio->private;
+	unsigned long *private_p;
+	unsigned long data_val;
+	if (!folio->mapping)
+		return 0;
+	f2fs_bug_on(F2FS_I_SB(folio_inode(folio)),!fifs);
+	if (READ_ONCE(fifs->read_bytes_pending) != F2FS_IFS_MAGIC)
+		return 0;
+
+	private_p = f2fs_ifs_private_flags_ptr(fifs, folio);
+	if (!private_p)
+		return 0;
+
+	data_val = READ_ONCE(*private_p); // Read atomically
+
+	if (!test_bit(PAGE_PRIVATE_NOT_POINTER, &data_val))
+		return 0; // Return 0 if NOT_POINTER isn't set
+
+	return data_val >> PAGE_PRIVATE_MAX;
+}
+
+inline int f2fs_set_folio_private_data(struct folio *folio, unsigned long data)
+{
+	
+	if (unlikely(!folio->mapping))
+		return -ENOENT;
+	
+	struct f2fs_iomap_folio_state *fifs = f2fs_ifs_alloc(folio, GFP_NOFS, true);
+	if (unlikely(!fifs))
+		return -ENOMEM;
+	
+	unsigned long *private_p;
+	unsigned long old_val, new_val;
+	
+	private_p = f2fs_ifs_private_flags_ptr(fifs, folio);
+	if (!private_p)
+		return -EINVAL;
+
+	// Atomically set the data part and the NOT_POINTER bit using cmpxchg loop
+	do {
+		old_val = READ_ONCE(*private_p);
+		new_val = old_val;
+		// Clear old data bits (bits >= PAGE_PRIVATE_MAX)
+		new_val &= GENMASK(PAGE_PRIVATE_MAX - 1, 0);
+		// Set new data bits
+		new_val |= (data << PAGE_PRIVATE_MAX);
+		// Ensure NOT_POINTER is set
+		__set_bit(PAGE_PRIVATE_NOT_POINTER, &new_val);
+	} while (cmpxchg(private_p, old_val, new_val) != old_val);
+
+	return 0;
+}
+
+inline void f2fs_clear_folio_private_data(struct folio *folio)
+{	
+	struct f2fs_iomap_folio_state *fifs = 
+		(struct f2fs_iomap_folio_state *)folio->private;
+	unsigned long *private_p;
+	unsigned long old_val, new_val;
+	f2fs_bug_on(F2FS_I_SB(folio_inode(folio)),!fifs);
+	if (!folio->mapping)
+		return;
+	if (READ_ONCE(fifs->read_bytes_pending) != F2FS_IFS_MAGIC)
+		return;
+
+	private_p = f2fs_ifs_private_flags_ptr(fifs, folio);
+	if (!private_p)
+		return;
+
+	// Atomically clear the data part, leave flags untouched
+	do {
+		old_val = READ_ONCE(*private_p);
+		// If already no data bits set, nothing to do
+		if ((old_val >> PAGE_PRIVATE_MAX) == 0)
+			break;
+		new_val = old_val;
+		// Clear data bits
+		new_val &= GENMASK(PAGE_PRIVATE_MAX - 1, 0);
+	} while (cmpxchg(private_p, old_val, new_val) != old_val);
+}
+
+inline void f2fs_clear_folio_private_all(struct folio *folio)
+{
+	struct f2fs_iomap_folio_state *fifs = 
+		(struct f2fs_iomap_folio_state *)folio->private;
+	unsigned long *private_p;
+
+	if (unlikely(!fifs || !folio->mapping))
+		return;
+	if (READ_ONCE(fifs->read_bytes_pending) != F2FS_IFS_MAGIC)
+		return;
+
+	private_p = f2fs_ifs_private_flags_ptr(fifs, folio);
+	if (!private_p)
+		return;
+		
+	// Clear all private flags/data
+	*private_p = 0;
+}

--- a/fs/f2fs/f2fs_ifs.h
+++ b/fs/f2fs/f2fs_ifs.h
@@ -11,7 +11,7 @@
 #include <linux/atomic.h> // For atomic_t and bitops
 #include "f2fs.h"
 #define F2FS_IFS_MAGIC 0xf2f5 
-#define F2FS_IFS_PRIVATE_LONGS 1
+#define F2FS_IFS_PRIVATE_LONGS 2
 /*
  * F2FS structure for folio private data, mimicking iomap_folio_state layout.
  * F2FS private flags/data are stored in extra space allocated at the end
@@ -24,6 +24,7 @@ struct f2fs_iomap_folio_state {
 	 * Flexible array member.
 	 * Holds [0...iomap_longs-1] for iomap uptodate/dirty bits.
 	 * Holds [iomap_longs] for F2FS private flags/data (unsigned long).
+	 * Holds [iomap_longs+1] for dirty_bytes_pending
 	 */
 	unsigned long state[];
 };
@@ -49,6 +50,12 @@ f2fs_ifs_private_flags_ptr(struct f2fs_iomap_folio_state *fifs, struct folio *fo
 {
 	return &fifs->state[f2fs_ifs_iomap_longs(folio)];
 }
+static inline atomic_t *
+f2fs_ifs_dirty_bytes_pending_ptr(struct f2fs_iomap_folio_state *fifs, struct folio *folio)
+{
+	// Treat the second private long as an atomic_t
+	return (atomic_t *)&fifs->state[f2fs_ifs_iomap_longs(folio) + 1];
+}
 
 /*Have to set parameter ifs's type to void*
 and have to interpret ifs as f2fs_ifs to acess it's fields because
@@ -71,7 +78,9 @@ inline void f2fs_clear_folio_private_all(struct folio *folio);
 /*0-order and fully dirty folio has no fifs
 they store private flag directly in their folio->private field
 as original f2fs page private behaviour*/
+unsigned f2fs_iomap_find_dirty_range(struct folio *folio, u64 *range_start,u64 range_end);
 void f2fs_ifs_clear_range_uptodate(struct folio *folio, struct f2fs_iomap_folio_state*fifs,size_t off, size_t len);
+void f2fs_iomap_finish_folio_read(struct folio *folio, size_t off,size_t len, int error);
 static inline bool is_f2fs_ifs(struct folio *folio)
 {
     if (!folio_test_private(folio))

--- a/fs/f2fs/f2fs_ifs.h
+++ b/fs/f2fs/f2fs_ifs.h
@@ -1,0 +1,200 @@
+#ifndef F2FS_IFS_H
+#define F2FS_IFS_H
+
+#include <linux/fs.h>
+#include <linux/bug.h>
+#include <linux/f2fs_fs.h>
+#include <linux/mm.h>
+#include <linux/iomap.h>
+#include <linux/slab.h>
+#include <linux/spinlock.h>
+#include <linux/atomic.h> // For atomic_t and bitops
+#include "f2fs.h"
+#define F2FS_IFS_MAGIC 0xf2f5 
+#define F2FS_IFS_PRIVATE_LONGS 1
+/*
+ * F2FS structure for folio private data, mimicking iomap_folio_state layout.
+ * F2FS private flags/data are stored in extra space allocated at the end
+ */
+struct f2fs_iomap_folio_state {
+	spinlock_t state_lock;
+	unsigned int read_bytes_pending;
+	atomic_t write_bytes_pending; 
+	/*
+	 * Flexible array member.
+	 * Holds [0...iomap_longs-1] for iomap uptodate/dirty bits.
+	 * Holds [iomap_longs] for F2FS private flags/data (unsigned long).
+	 */
+	unsigned long state[];
+};
+static inline bool f2fs_ifs_block_is_uptodate(struct f2fs_iomap_folio_state *ifs,
+		unsigned int block)
+{
+	return test_bit(block, ifs->state);
+}
+static inline size_t f2fs_ifs_iomap_longs(struct folio *folio)
+{
+	struct inode* inode=folio->mapping->host;
+	WARN_ON_ONCE(inode==NULL);
+	unsigned int nr_blocks = i_blocks_per_folio(inode, folio);
+	return BITS_TO_LONGS(2 * nr_blocks);
+}
+static inline size_t f2fs_ifs_total_longs(struct folio *folio)
+{
+	return f2fs_ifs_iomap_longs(folio) + F2FS_IFS_PRIVATE_LONGS;
+}
+
+static inline unsigned long *
+f2fs_ifs_private_flags_ptr(struct f2fs_iomap_folio_state *fifs, struct folio *folio)
+{
+	return &fifs->state[f2fs_ifs_iomap_longs(folio)];
+}
+
+/*Have to set parameter ifs's type to void*
+and have to interpret ifs as f2fs_ifs to acess it's fields because
+we cannot see iomap_folio_state definition*/
+static void ifs_to_f2fs_ifs(void *ifs, struct f2fs_iomap_folio_state *fifs, struct folio *folio)
+{
+	struct f2fs_iomap_folio_state *src_ifs = (struct f2fs_iomap_folio_state *)ifs;
+	size_t iomap_longs = f2fs_ifs_iomap_longs(folio);
+	fifs->read_bytes_pending = READ_ONCE(src_ifs->read_bytes_pending);
+	atomic_set(&fifs->write_bytes_pending, atomic_read(&src_ifs->write_bytes_pending));
+	memcpy(fifs->state, src_ifs->state, iomap_longs * sizeof(unsigned long));
+}
+struct f2fs_iomap_folio_state *f2fs_ifs_alloc(struct folio *folio, gfp_t gfp,bool force_alloc);
+void f2fs_ifs_free(struct folio *folio);
+struct f2fs_iomap_folio_state *f2fs_folio_get_private(struct folio *folio);
+inline unsigned long f2fs_get_folio_private_data(struct folio *folio);
+inline int f2fs_set_folio_private_data(struct folio *folio,unsigned long data);
+inline void f2fs_clear_folio_private_data(struct folio *folio);
+inline void f2fs_clear_folio_private_all(struct folio *folio);
+/*0-order and fully dirty folio has no fifs
+they store private flag directly in their folio->private field
+as original f2fs page private behaviour*/
+void f2fs_ifs_clear_range_uptodate(struct folio *folio, struct f2fs_iomap_folio_state*fifs,size_t off, size_t len);
+static inline bool is_f2fs_ifs(struct folio *folio)
+{
+    if (!folio_test_private(folio))
+        return false;
+        
+    // first directly test no pointer flag is set or not
+    if (test_bit(PAGE_PRIVATE_NOT_POINTER, (unsigned long *)&folio->private))
+        return false;
+        
+    struct f2fs_iomap_folio_state *fifs;
+    fifs = (struct f2fs_iomap_folio_state *)folio->private;
+    if (!fifs)
+        return false;
+    if (READ_ONCE(fifs->read_bytes_pending) == F2FS_IFS_MAGIC) {
+        return true;
+    }
+    return false;
+}
+#define F2FS_FOLIO_PRIVATE_GET_FUNC(name, flagname)                                \
+	static inline bool f2fs_folio_private_##name(struct folio *folio)          \
+	{   																	\
+		/* First try direct folio->private access for meta folio */                       \
+		if (folio_test_private(folio) &&                                   \
+		    test_bit(PAGE_PRIVATE_NOT_POINTER,                             \
+			     (unsigned long *)&folio->private)) {                  \
+			return test_bit(PAGE_PRIVATE_##flagname,                   \
+					(unsigned long *)&folio->private);        \
+		}																	\
+		/* For higher-order folios, use iomap folio state */               \
+		struct f2fs_iomap_folio_state *fifs =                              \
+			(struct f2fs_iomap_folio_state *)folio->private;           \
+		unsigned long *private_p;                                          \
+		if (unlikely(!fifs || !folio->mapping))                            \
+			return false;                                               \
+		/* Check magic number before accessing private data */             \
+		if (READ_ONCE(fifs->read_bytes_pending) != F2FS_IFS_MAGIC)         \
+			return false;                                               \
+		private_p = f2fs_ifs_private_flags_ptr(fifs, folio);               \
+		if (!private_p)                                                    \
+			return false;                                               \
+		/* Test bits directly on the 'private' slot */                     \
+		return test_bit(PAGE_PRIVATE_##flagname, private_p);               \
+	}
+
+#define F2FS_FOLIO_PRIVATE_SET_FUNC(name, flagname)                               \
+	static inline int f2fs_set_folio_private_##name(struct folio *folio)      \
+	{                                                                         \
+		/* For higher-order folios, use iomap folio state */             \
+		if (unlikely(!folio->mapping))                                   \
+			return -ENOENT;													\
+		bool force_alloc=f2fs_should_use_buffered_iomap(folio_inode(folio)); \
+		if (!force_alloc && !folio_test_private(folio)) {                 \
+			folio_attach_private(folio, (void *)0);                   \
+			set_bit(PAGE_PRIVATE_NOT_POINTER,                         \
+				(unsigned long *)&folio->private);               \
+			set_bit(PAGE_PRIVATE_##flagname,                          \
+				(unsigned long *)&folio->private);               \
+			return 0;                                                 \
+		}     															\
+		struct f2fs_iomap_folio_state *fifs =                            \
+			f2fs_ifs_alloc(folio, GFP_NOFS,true);                         \
+		if(unlikely(!fifs))                                              \
+			return -ENOMEM;                                           \
+		unsigned long *private_p;                                        \
+		WRITE_ONCE(fifs->read_bytes_pending, F2FS_IFS_MAGIC);            \
+		private_p = f2fs_ifs_private_flags_ptr(fifs, folio);             \
+		if (!private_p)                                                  \
+			return -EINVAL;                                           \
+		/* Set the bit atomically */                                     \
+		set_bit(PAGE_PRIVATE_##flagname, private_p);                     \
+		/* Ensure NOT_POINTER bit is also set if any F2FS flag is set */ \
+		if (PAGE_PRIVATE_##flagname != PAGE_PRIVATE_NOT_POINTER)         \
+			set_bit(PAGE_PRIVATE_NOT_POINTER, private_p);            \
+		return 0;                                                        \
+	}
+
+#define F2FS_FOLIO_PRIVATE_CLEAR_FUNC(name, flagname)                         \
+	static inline void f2fs_clear_folio_private_##name(                   \
+		struct folio *folio)                                          \
+	{                            										\
+			/* First try direct folio->private access */                  \
+		if (folio_test_private(folio) &&                              \
+		    test_bit(PAGE_PRIVATE_NOT_POINTER,                        \
+			     (unsigned long *)&folio->private)) {             \
+			clear_bit(PAGE_PRIVATE_##flagname,                    \
+				  (unsigned long *)&folio->private);          \
+			folio_detach_private(folio);                  \
+			return;                                               \
+		}                                                             \
+		/* For higher-order folios, use iomap folio state */         \
+		struct f2fs_iomap_folio_state *fifs =                         \
+			(struct f2fs_iomap_folio_state *)folio->private;      \
+		unsigned long *private_p;                                     \
+		if (unlikely(!fifs || !folio->mapping))                       \
+			return;                                               \
+		/* Check magic number before clearing */                      \
+		if (READ_ONCE(fifs->read_bytes_pending) != F2FS_IFS_MAGIC)    \
+			return; /* Not ours or state unclear */               \
+		private_p = f2fs_ifs_private_flags_ptr(fifs, folio);          \
+		if (!private_p)                                               \
+			return;                                               \
+		clear_bit(PAGE_PRIVATE_##flagname, private_p);                \
+	}
+
+// Generate the accessor functions using the macros
+F2FS_FOLIO_PRIVATE_GET_FUNC(nonpointer, NOT_POINTER);
+F2FS_FOLIO_PRIVATE_GET_FUNC(inline, INLINE_INODE);
+F2FS_FOLIO_PRIVATE_GET_FUNC(gcing, ONGOING_MIGRATION);
+F2FS_FOLIO_PRIVATE_GET_FUNC(atomic, ATOMIC_WRITE);
+F2FS_FOLIO_PRIVATE_GET_FUNC(reference, REF_RESOURCE);
+F2FS_FOLIO_PRIVATE_GET_FUNC(deferred_unlock, DEFERRED_UNLOCK);
+
+F2FS_FOLIO_PRIVATE_SET_FUNC(reference, REF_RESOURCE);
+F2FS_FOLIO_PRIVATE_SET_FUNC(inline, INLINE_INODE);
+F2FS_FOLIO_PRIVATE_SET_FUNC(gcing, ONGOING_MIGRATION);
+F2FS_FOLIO_PRIVATE_SET_FUNC(atomic, ATOMIC_WRITE);
+F2FS_FOLIO_PRIVATE_SET_FUNC(deferred_unlock, DEFERRED_UNLOCK);
+
+F2FS_FOLIO_PRIVATE_CLEAR_FUNC(reference, REF_RESOURCE);
+F2FS_FOLIO_PRIVATE_CLEAR_FUNC(inline, INLINE_INODE);
+F2FS_FOLIO_PRIVATE_CLEAR_FUNC(gcing, ONGOING_MIGRATION);
+F2FS_FOLIO_PRIVATE_CLEAR_FUNC(atomic, ATOMIC_WRITE);
+F2FS_FOLIO_PRIVATE_CLEAR_FUNC(deferred_unlock, DEFERRED_UNLOCK);
+// --- Data access functions ---
+#endif /* F2FS_IFS_H */
+

--- a/fs/f2fs/file.c
+++ b/fs/f2fs/file.c
@@ -32,6 +32,7 @@
 #include "acl.h"
 #include "gc.h"
 #include "iostat.h"
+#include "f2fs_ifs.h"
 #include <trace/events/f2fs.h>
 #include <uapi/linux/f2fs.h>
 
@@ -4899,6 +4900,10 @@ static int f2fs_preallocate_blocks(struct kiocb *iocb, struct iov_iter *iter,
 		ret = f2fs_convert_inline_inode(inode);
 		if (ret)
 			return ret;
+		/*buffered write can convert inline file to large normal file
+		when convert success, we uses mapping set large folios here*/
+		if(f2fs_should_use_buffered_iomap(inode))
+			mapping_set_large_folios(inode->i_mapping);
 	}
 
 	/* Do not preallocate blocks that will be written partially in 4KB. */
@@ -4929,8 +4934,22 @@ static int f2fs_preallocate_blocks(struct kiocb *iocb, struct iov_iter *iter,
 	return map.m_len;
 }
 
-static ssize_t f2fs_buffered_write_iter(struct kiocb *iocb,
-					struct iov_iter *from)
+static ssize_t f2fs_iomap_buffered_write(struct kiocb *iocb, struct iov_iter *i)
+{
+	struct file *file = iocb->ki_filp;
+	struct inode *inode = file_inode(file);
+	ssize_t ret;
+	if (f2fs_is_atomic_file(inode)) {
+		ret = iomap_file_buffered_write(
+			iocb, i, &f2fs_buffered_write_atomic_iomap_ops, NULL);
+	} else {
+		ret = iomap_file_buffered_write(
+			iocb, i, &f2fs_buffered_write_iomap_ops, NULL);
+	}
+	return ret;
+}
+static ssize_t
+f2fs_buffered_write_iter(struct kiocb *iocb, struct iov_iter *from)
 {
 	struct file *file = iocb->ki_filp;
 	struct inode *inode = file_inode(file);
@@ -4938,9 +4957,14 @@ static ssize_t f2fs_buffered_write_iter(struct kiocb *iocb,
 
 	if (iocb->ki_flags & IOCB_NOWAIT)
 		return -EOPNOTSUPP;
-
-	ret = generic_perform_write(iocb, from);
-
+	if(f2fs_should_use_buffered_iomap(inode))
+	{
+		ret = f2fs_iomap_buffered_write(iocb, from);
+	}
+	else
+	{
+		ret = generic_perform_write(iocb, from);
+	}
 	if (ret > 0) {
 		f2fs_update_iostat(F2FS_I_SB(inode), inode,
 						APP_BUFFERED_IO, ret);

--- a/fs/f2fs/file.c
+++ b/fs/f2fs/file.c
@@ -616,7 +616,6 @@ static int f2fs_file_open(struct inode *inode, struct file *filp)
 
 	return finish_preallocate_blocks(inode);
 }
-
 void f2fs_truncate_data_blocks_range(struct dnode_of_data *dn, int count)
 {
 	struct f2fs_sb_info *sbi = F2FS_I_SB(dn->inode);
@@ -741,7 +740,6 @@ truncate_out:
 	f2fs_folio_put(folio, true);
 	return 0;
 }
-
 int f2fs_do_truncate_blocks(struct inode *inode, u64 from, bool lock)
 {
 	struct f2fs_sb_info *sbi = F2FS_I_SB(inode);
@@ -2186,7 +2184,6 @@ static int f2fs_ioc_getversion(struct file *filp, unsigned long arg)
 
 	return put_user(inode->i_generation, (int __user *)arg);
 }
-
 static int f2fs_ioc_start_atomic_write(struct file *filp, bool truncate)
 {
 	struct inode *inode = file_inode(filp);
@@ -4966,12 +4963,11 @@ f2fs_buffered_write_iter(struct kiocb *iocb, struct iov_iter *from)
 		ret = generic_perform_write(iocb, from);
 	}
 	if (ret > 0) {
-		f2fs_update_iostat(F2FS_I_SB(inode), inode,
-						APP_BUFFERED_IO, ret);
+		f2fs_update_iostat(F2FS_I_SB(inode), inode, APP_BUFFERED_IO,
+				   ret);
 	}
 	return ret;
 }
-
 static int f2fs_dio_write_end_io(struct kiocb *iocb, ssize_t size, int error,
 				 unsigned int flags)
 {

--- a/fs/f2fs/gc.c
+++ b/fs/f2fs/gc.c
@@ -21,6 +21,7 @@
 #include "segment.h"
 #include "gc.h"
 #include "iostat.h"
+#include "f2fs_ifs.h"
 #include <trace/events/f2fs.h>
 
 static struct kmem_cache *victim_entry_slab;
@@ -1472,8 +1473,15 @@ static int move_data_page(struct inode *inode, block_t bidx, int gc_type,
 			err = -EAGAIN;
 			goto out;
 		}
-		folio_mark_dirty(folio);
-		set_page_private_gcing(&folio->page);
+		f2fs_set_folio_private_gcing(folio);
+		if(folio_order(folio)==0)
+		{
+			folio_mark_dirty(folio);
+		}
+		else
+		{
+			iomap_set_range_dirty(folio,bidx<<PAGE_SHIFT,PAGE_SIZE);
+		}
 	} else {
 		struct f2fs_io_info fio = {
 			.sbi = F2FS_I_SB(inode),
@@ -1499,11 +1507,11 @@ retry:
 			f2fs_remove_dirty_inode(inode);
 		}
 
-		set_page_private_gcing(&folio->page);
+		f2fs_set_folio_private_gcing(folio);
 
 		err = f2fs_do_write_data_page(&fio);
 		if (err) {
-			clear_page_private_gcing(&folio->page);
+			f2fs_clear_folio_private_gcing(folio);
 			if (err == -ENOMEM) {
 				memalloc_retry_wait(GFP_NOFS);
 				goto retry;

--- a/fs/f2fs/gc.c
+++ b/fs/f2fs/gc.c
@@ -1222,7 +1222,6 @@ static int ra_data_block(struct inode *inode, pgoff_t index)
 	folio = f2fs_grab_cache_folio(mapping, index, true);
 	if (IS_ERR(folio))
 		return PTR_ERR(folio);
-
 	if (f2fs_lookup_read_extent_cache_block(inode, index,
 						&dn.data_blkaddr)) {
 		if (unlikely(!f2fs_is_valid_blkaddr(sbi, dn.data_blkaddr,
@@ -1260,7 +1259,6 @@ got_it:
 	f2fs_folio_wait_writeback(folio, DATA, true, true);
 
 	f2fs_wait_on_block_writeback(inode, dn.data_blkaddr);
-
 	fio.encrypted_page = f2fs_pagecache_get_page(META_MAPPING(sbi),
 					dn.data_blkaddr,
 					FGP_LOCK | FGP_CREAT, GFP_NOFS);
@@ -1315,12 +1313,14 @@ static int move_data_block(struct inode *inode, block_t bidx,
 	int type = fio.sbi->am.atgc_enabled && (gc_type == BG_GC) &&
 				(fio.sbi->gc_mode != GC_URGENT_HIGH) ?
 				CURSEG_ALL_DATA_ATGC : CURSEG_COLD_DATA;
-
+	
 	/* do not read out */
 	folio = f2fs_grab_cache_folio(mapping, bidx, false);
 	if (IS_ERR(folio))
 		return PTR_ERR(folio);
-
+	// #ifdef CONFIG_FS_IOMAP_DEBUG_PRINT
+	// FUNC(print_folio,folio);
+	// #endif
 	if (!check_valid_map(F2FS_I_SB(inode), segno, off)) {
 		err = -ENOENT;
 		goto out;
@@ -1454,7 +1454,6 @@ static int move_data_page(struct inode *inode, block_t bidx, int gc_type,
 {
 	struct folio *folio;
 	int err = 0;
-
 	folio = f2fs_get_lock_data_folio(inode, bidx, true);
 	if (IS_ERR(folio))
 		return PTR_ERR(folio);
@@ -1524,7 +1523,6 @@ out:
 	f2fs_folio_put(folio, true);
 	return err;
 }
-
 /*
  * This function tries to get parent node of victim data block, and identifies
  * data block validity. If the block is valid, copy that with cold status and

--- a/fs/f2fs/inline.c
+++ b/fs/f2fs/inline.c
@@ -13,7 +13,7 @@
 #include "f2fs.h"
 #include "node.h"
 #include <trace/events/f2fs.h>
-
+#include <linux/iomap.h>
 static bool support_inline_data(struct inode *inode)
 {
 	if (f2fs_used_in_atomic_write(inode))
@@ -831,4 +831,15 @@ int f2fs_inline_data_fiemap(struct inode *inode,
 out:
 	f2fs_folio_put(ifolio, true);
 	return err;
+}
+/*fill iomap struct for inline data case for
+iomap buffered write*/
+void f2fs_iomap_prepare_read_inline(struct inode* inode,struct folio* ifolio,struct iomap* iomap,
+loff_t pos,loff_t length)
+{
+	iomap->addr = IOMAP_NULL_ADDR;
+	iomap->length = length;
+	iomap->type = IOMAP_INLINE;
+	iomap->flags = 0; 	
+	iomap->inline_data=inline_data_addr(inode, ifolio);			
 }

--- a/fs/f2fs/inode.c
+++ b/fs/f2fs/inode.c
@@ -11,7 +11,7 @@
 #include <linux/sched/mm.h>
 #include <linux/lz4.h>
 #include <linux/zstd.h>
-
+#include <linux/pagemap.h>
 #include "f2fs.h"
 #include "node.h"
 #include "segment.h"
@@ -22,7 +22,24 @@
 #ifdef CONFIG_F2FS_FS_COMPRESSION
 extern const struct address_space_operations f2fs_compress_aops;
 #endif
-
+bool f2fs_should_use_buffered_iomap(struct inode *inode)
+{
+ 	if (!S_ISREG(inode->i_mode))
+		return false;
+	if(S_ISDIR(inode->i_mode)||S_ISLNK(inode->i_mode))
+		return false;
+	if(inode->i_mapping==NODE_MAPPING(F2FS_I_SB(inode)))
+		return false;
+	if(inode->i_mapping==META_MAPPING(F2FS_I_SB(inode)))
+		return false;
+	if (f2fs_is_atomic_file(inode) && !is_inode_flag_set(inode, FI_ATOMIC_COMMITTED))
+		return false;
+	if (f2fs_is_pinned_file(inode))
+		return false;
+	if (f2fs_has_inline_data(inode))
+		return false;
+	return true;
+}
 void f2fs_mark_inode_dirty_sync(struct inode *inode, bool sync)
 {
 	if (is_inode_flag_set(inode, FI_NEW_INODE))
@@ -611,7 +628,14 @@ make_now:
 	} else if (S_ISREG(inode->i_mode)) {
 		inode->i_op = &f2fs_file_inode_operations;
 		inode->i_fop = &f2fs_file_operations;
-		inode->i_mapping->a_ops = &f2fs_dblock_aops;
+		// inode->i_mapping->a_ops = &f2fs_dblock_aops;
+		if(f2fs_should_use_buffered_iomap(inode))
+		{
+			mapping_set_large_folios(inode->i_mapping);
+			inode->i_mapping->a_ops = &f2fs_iomap_aops;
+		}
+		else
+			inode->i_mapping->a_ops = &f2fs_dblock_aops;
 	} else if (S_ISDIR(inode->i_mode)) {
 		inode->i_op = &f2fs_dir_inode_operations;
 		inode->i_fop = &f2fs_dir_operations;
@@ -865,8 +889,10 @@ void f2fs_evict_inode(struct inode *inode)
 			inode->i_ino == F2FS_META_INO(sbi) ||
 			inode->i_ino == F2FS_COMPRESS_INO(sbi))
 		goto out_clear;
-
-	f2fs_bug_on(sbi, get_dirty_pages(inode));
+	/*temporarily comment it.Because it will cause panic in my folio dev.
+	We haven't fully understand how to count dirty pages when introducing
+	large folios*/
+	// f2fs_bug_on(sbi, get_dirty_pages(inode));
 	f2fs_remove_dirty_inode(inode);
 	f2fs_remove_donate_inode(inode);
 

--- a/fs/f2fs/namei.c
+++ b/fs/f2fs/namei.c
@@ -135,7 +135,6 @@ int f2fs_update_extension_list(struct f2fs_sb_info *sbi, const char *name,
 	}
 	return 0;
 }
-
 static void set_compress_new_inode(struct f2fs_sb_info *sbi, struct inode *dir,
 				struct inode *inode, const unsigned char *name)
 {
@@ -215,7 +214,6 @@ static void set_file_temperature(struct f2fs_sb_info *sbi, struct inode *inode,
 	else
 		file_set_hot(inode);
 }
-
 static struct inode *f2fs_new_inode(struct mnt_idmap *idmap,
 						struct inode *dir, umode_t mode,
 						const char *name)

--- a/fs/f2fs/namei.c
+++ b/fs/f2fs/namei.c
@@ -328,6 +328,8 @@ static struct inode *f2fs_new_inode(struct mnt_idmap *idmap,
 	f2fs_init_extent_tree(inode);
 
 	trace_f2fs_new_inode(inode, 0);
+	if(f2fs_should_use_buffered_iomap(inode))
+		mapping_set_large_folios(inode->i_mapping);
 	return inode;
 
 fail:

--- a/fs/f2fs/node.c
+++ b/fs/f2fs/node.c
@@ -853,7 +853,6 @@ int f2fs_get_dnode_of_data(struct dnode_of_data *dn, pgoff_t index, int mode)
 	dn->ofs_in_node = offset[level];
 	dn->node_folio = nfolio[level];
 	dn->data_blkaddr = f2fs_data_blkaddr(dn);
-
 	if (is_inode_flag_set(dn->inode, FI_COMPRESSED_FILE) &&
 					f2fs_sb_has_readonly(sbi)) {
 		unsigned int cluster_size = F2FS_I(dn->inode)->i_cluster_size;

--- a/fs/f2fs/node.c
+++ b/fs/f2fs/node.c
@@ -18,8 +18,8 @@
 #include "segment.h"
 #include "xattr.h"
 #include "iostat.h"
+#include "f2fs_ifs.h"
 #include <trace/events/f2fs.h>
-
 #define on_f2fs_build_free_nids(nm_i) mutex_is_locked(&(nm_i)->build_lock)
 
 static struct kmem_cache *nat_entry_slab;
@@ -2218,7 +2218,7 @@ static bool f2fs_dirty_node_folio(struct address_space *mapping,
 #endif
 	if (filemap_dirty_folio(mapping, folio)) {
 		inc_page_count(F2FS_M_SB(mapping), F2FS_DIRTY_NODES);
-		set_page_private_reference(&folio->page);
+		f2fs_set_folio_private_reference(folio);
 		return true;
 	}
 	return false;

--- a/fs/f2fs/segment.c
+++ b/fs/f2fs/segment.c
@@ -23,6 +23,7 @@
 #include "node.h"
 #include "gc.h"
 #include "iostat.h"
+#include "f2fs_ifs.h"
 #include <trace/events/f2fs.h>
 
 #define __reverse_ffz(x) __reverse_ffs(~(x))
@@ -3630,7 +3631,7 @@ static int __get_segment_type_6(struct f2fs_io_info *fio)
 		if (is_inode_flag_set(inode, FI_ALIGNED_WRITE))
 			return CURSEG_COLD_DATA_PINNED;
 
-		if (page_private_gcing(fio->page)) {
+		if (f2fs_folio_private_gcing(page_folio(fio->page))) {
 			if (fio->sbi->am.atgc_enabled &&
 				(fio->io_type == FS_DATA_IO) &&
 				(fio->sbi->gc_mode != GC_URGENT_HIGH) &&
@@ -3914,7 +3915,7 @@ static void do_write_page(struct f2fs_summary *sum, struct f2fs_io_info *fio)
 	int seg_type = log_type_to_seg_type(type);
 	bool keep_order = (f2fs_lfs_mode(fio->sbi) &&
 				seg_type == CURSEG_COLD_DATA);
-
+				
 	if (keep_order)
 		f2fs_down_read(&fio->sbi->io_order_lock);
 

--- a/fs/f2fs/segment.c
+++ b/fs/f2fs/segment.c
@@ -2580,7 +2580,6 @@ static void update_sit_entry(struct f2fs_sb_info *sbi, block_t blkaddr, int del)
 	if (__is_large_section(sbi))
 		get_sec_entry(sbi, segno)->valid_blocks += del;
 }
-
 void f2fs_invalidate_blocks(struct f2fs_sb_info *sbi, block_t addr,
 				unsigned int len)
 {
@@ -3911,6 +3910,7 @@ static int log_type_to_seg_type(enum log_type type)
 static void do_write_page(struct f2fs_summary *sum, struct f2fs_io_info *fio)
 {
 	struct folio *folio = page_folio(fio->page);
+	/* LFS mode write path */
 	enum log_type type = __get_segment_type(fio);
 	int seg_type = log_type_to_seg_type(type);
 	bool keep_order = (f2fs_lfs_mode(fio->sbi) &&
@@ -3930,10 +3930,8 @@ static void do_write_page(struct f2fs_summary *sum, struct f2fs_io_info *fio)
 	}
 	if (GET_SEGNO(fio->sbi, fio->old_blkaddr) != NULL_SEGNO)
 		f2fs_invalidate_internal_cache(fio->sbi, fio->old_blkaddr, 1);
-
 	/* writeout dirty page into bdev */
 	f2fs_submit_page_write(fio);
-
 	f2fs_update_device_state(fio->sbi, fio->ino, fio->new_blkaddr, 1);
 out:
 	if (keep_order)
@@ -3981,7 +3979,7 @@ void f2fs_outplace_write_data(struct dnode_of_data *dn,
 {
 	struct f2fs_sb_info *sbi = fio->sbi;
 	struct f2fs_summary sum;
-
+	
 	f2fs_bug_on(sbi, dn->data_blkaddr == NULL_ADDR);
 	if (fio->io_type == FS_DATA_IO || fio->io_type == FS_CP_DATA_IO)
 		f2fs_update_age_extent_cache(dn);

--- a/fs/iomap/buffered-io.c
+++ b/fs/iomap/buffered-io.c
@@ -20,7 +20,9 @@
 #include "trace.h"
 
 #include "../internal.h"
-
+#ifdef CONFIG_FS_IOMAP_DEBUG_PRINT
+#include "../fs_dbg.h"
+#endif
 /*
  * Structure allocated for each folio to track per-block uptodate, dirty state
  * and I/O completions.
@@ -45,14 +47,14 @@ static inline bool ifs_is_fully_uptodate(struct folio *folio,
 
 	return bitmap_full(ifs->state, i_blocks_per_folio(inode, folio));
 }
-
-static inline bool ifs_block_is_uptodate(struct iomap_folio_state *ifs,
+/*My change: remove static */
+inline bool ifs_block_is_uptodate(struct iomap_folio_state *ifs,
 		unsigned int block)
 {
 	return test_bit(block, ifs->state);
 }
-
-static bool ifs_set_range_uptodate(struct folio *folio,
+/*My change: remove static*/
+bool ifs_set_range_uptodate(struct folio *folio,
 		struct iomap_folio_state *ifs, size_t off, size_t len)
 {
 	struct inode *inode = folio->mapping->host;
@@ -63,8 +65,9 @@ static bool ifs_set_range_uptodate(struct folio *folio,
 	bitmap_set(ifs->state, first_blk, nr_blks);
 	return ifs_is_fully_uptodate(folio, ifs);
 }
-
-static void iomap_set_range_uptodate(struct folio *folio, size_t off,
+EXPORT_SYMBOL_GPL(ifs_set_range_uptodate);
+/*My change: remove static*/
+void iomap_set_range_uptodate(struct folio *folio, size_t off,
 		size_t len)
 {
 	struct iomap_folio_state *ifs = folio->private;
@@ -80,7 +83,8 @@ static void iomap_set_range_uptodate(struct folio *folio, size_t off,
 	if (uptodate)
 		folio_mark_uptodate(folio);
 }
-
+/*Mychange: add export*/
+EXPORT_SYMBOL_GPL(iomap_set_range_uptodate);
 static inline bool ifs_block_is_dirty(struct folio *folio,
 		struct iomap_folio_state *ifs, int block)
 {
@@ -114,8 +118,8 @@ static unsigned ifs_find_dirty_range(struct folio *folio,
 	*range_start = folio_pos(folio) + (start_blk << inode->i_blkbits);
 	return nblks << inode->i_blkbits;
 }
-
-static unsigned iomap_find_dirty_range(struct folio *folio, u64 *range_start,
+/*My change: remove static*/
+unsigned iomap_find_dirty_range(struct folio *folio, u64 *range_start,
 		u64 range_end)
 {
 	struct iomap_folio_state *ifs = folio->private;
@@ -127,7 +131,7 @@ static unsigned iomap_find_dirty_range(struct folio *folio, u64 *range_start,
 		return ifs_find_dirty_range(folio, ifs, range_start, range_end);
 	return range_end - *range_start;
 }
-
+EXPORT_SYMBOL_GPL(iomap_find_dirty_range);
 static void ifs_clear_range_dirty(struct folio *folio,
 		struct iomap_folio_state *ifs, size_t off, size_t len)
 {
@@ -143,14 +147,14 @@ static void ifs_clear_range_dirty(struct folio *folio,
 	spin_unlock_irqrestore(&ifs->state_lock, flags);
 }
 
-static void iomap_clear_range_dirty(struct folio *folio, size_t off, size_t len)
+void iomap_clear_range_dirty(struct folio *folio, size_t off, size_t len)
 {
 	struct iomap_folio_state *ifs = folio->private;
 
 	if (ifs)
 		ifs_clear_range_dirty(folio, ifs, off, len);
 }
-
+EXPORT_SYMBOL_GPL(iomap_clear_range_dirty);
 static void ifs_set_range_dirty(struct folio *folio,
 		struct iomap_folio_state *ifs, size_t off, size_t len)
 {
@@ -165,15 +169,15 @@ static void ifs_set_range_dirty(struct folio *folio,
 	bitmap_set(ifs->state, first_blk + blks_per_folio, nr_blks);
 	spin_unlock_irqrestore(&ifs->state_lock, flags);
 }
-
-static void iomap_set_range_dirty(struct folio *folio, size_t off, size_t len)
+/*Mychange:remove static*/
+void iomap_set_range_dirty(struct folio *folio, size_t off, size_t len)
 {
 	struct iomap_folio_state *ifs = folio->private;
 
 	if (ifs)
 		ifs_set_range_dirty(folio, ifs, off, len);
 }
-
+EXPORT_SYMBOL_GPL(iomap_set_range_dirty);
 static struct iomap_folio_state *ifs_alloc(struct inode *inode,
 		struct folio *folio, unsigned int flags)
 {
@@ -226,7 +230,9 @@ static void ifs_free(struct folio *folio)
 /*
  * Calculate the range inside the folio that we actually need to read.
  */
-static void iomap_adjust_read_range(struct inode *inode, struct folio *folio,
+/*mychange 去掉了static*/
+__attribute__((optimize("O0")))
+void iomap_adjust_read_range(struct inode *inode, struct folio *folio,
 		loff_t *pos, loff_t length, size_t *offp, size_t *lenp)
 {
 	struct iomap_folio_state *ifs = folio->private;
@@ -283,7 +289,7 @@ static void iomap_adjust_read_range(struct inode *inode, struct folio *folio,
 	*offp = poff;
 	*lenp = plen;
 }
-
+EXPORT_SYMBOL_GPL(iomap_adjust_read_range);
 static void iomap_finish_folio_read(struct folio *folio, size_t off,
 		size_t len, int error)
 {
@@ -351,8 +357,8 @@ static int iomap_read_inline_data(const struct iomap_iter *iter,
 	iomap_set_range_uptodate(folio, offset, folio_size(folio) - offset);
 	return 0;
 }
-
-static inline bool iomap_block_needs_zeroing(const struct iomap_iter *iter,
+/*mychange 去掉了static*/
+inline bool iomap_block_needs_zeroing(const struct iomap_iter *iter,
 		loff_t pos)
 {
 	const struct iomap *srcmap = iomap_iter_srcmap(iter);
@@ -361,7 +367,7 @@ static inline bool iomap_block_needs_zeroing(const struct iomap_iter *iter,
 		(srcmap->flags & IOMAP_F_NEW) ||
 		pos >= i_size_read(iter->inode);
 }
-
+EXPORT_SYMBOL_GPL(iomap_block_needs_zeroing);
 static int iomap_readpage_iter(struct iomap_iter *iter,
 		struct iomap_readpage_ctx *ctx)
 {
@@ -678,7 +684,7 @@ static int iomap_read_folio_sync(loff_t block_start, struct folio *folio,
 	bio_add_folio_nofail(&bio, folio, plen, poff);
 	return submit_bio_wait(&bio);
 }
-
+__attribute__((optimize("O0")))
 static int __iomap_write_begin(const struct iomap_iter *iter, loff_t pos,
 		size_t len, struct folio *folio)
 {
@@ -773,7 +779,7 @@ static int iomap_write_begin_inline(const struct iomap_iter *iter,
 		return -EIO;
 	return iomap_read_inline_data(iter, folio);
 }
-
+__attribute__((optimize("O0")))
 static int iomap_write_begin(struct iomap_iter *iter, loff_t pos,
 		size_t len, struct folio **foliop)
 {
@@ -837,7 +843,7 @@ out_unlock:
 
 	return status;
 }
-
+__attribute__((optimize("O0")))
 static bool __iomap_write_end(struct inode *inode, loff_t pos, size_t len,
 		size_t copied, struct folio *folio)
 {
@@ -861,7 +867,7 @@ static bool __iomap_write_end(struct inode *inode, loff_t pos, size_t len,
 	filemap_dirty_folio(inode->i_mapping, folio);
 	return true;
 }
-
+__attribute__((optimize("O0")))
 static void iomap_write_end_inline(const struct iomap_iter *iter,
 		struct folio *folio, loff_t pos, size_t copied)
 {
@@ -883,6 +889,7 @@ static void iomap_write_end_inline(const struct iomap_iter *iter,
  * Returns true if all copied bytes have been written to the pagecache,
  * otherwise return false.
  */
+__attribute__((optimize("O0")))
 static bool iomap_write_end(struct iomap_iter *iter, loff_t pos, size_t len,
 		size_t copied, struct folio *folio)
 {
@@ -904,7 +911,7 @@ static bool iomap_write_end(struct iomap_iter *iter, loff_t pos, size_t len,
 
 	return __iomap_write_end(iter->inode, pos, len, copied, folio);
 }
-
+__attribute__((optimize("O0")))
 static int iomap_write_iter(struct iomap_iter *iter, struct iov_iter *i)
 {
 	ssize_t total_written = 0;
@@ -933,7 +940,10 @@ retry:
 
 		if (bytes > iomap_length(iter))
 			bytes = iomap_length(iter);
-
+		// /*my_debug*/
+		// printk(KERN_EMERG "iomap_write_iter: pos %lld, bytes %zu, offset %zu\n",
+		//        pos, bytes, offset);
+		/*my_debug*/
 		/*
 		 * Bring in the user page that we'll copy from _first_.
 		 * Otherwise there's a nasty deadlock on copying from the
@@ -956,7 +966,9 @@ retry:
 		}
 		if (iter->iomap.flags & IOMAP_F_STALE)
 			break;
-
+		// /*my_debug*/
+		// printk(KERN_EMERG "iomap_write_iter: folio order %d\n",folio_order(folio));
+		// /*my_debug*/
 		offset = offset_in_folio(folio, pos);
 		if (bytes > folio_size(folio) - offset)
 			bytes = folio_size(folio) - offset;
@@ -965,6 +977,9 @@ retry:
 			flush_dcache_folio(folio);
 
 		copied = copy_folio_from_iter_atomic(folio, offset, bytes, i);
+		// /*my_debug*/
+		// printk(KERN_EMERG "iomap_write_iter: copied bytes %d\n",copied);
+		// /*my_debug*/
 		written = iomap_write_end(iter, pos, bytes, copied, folio) ?
 			  copied : 0;
 
@@ -1799,7 +1814,8 @@ static int iomap_writepage_map_blocks(struct iomap_writepage_ctx *wpc,
  * If the folio is entirely beyond i_size, return false.  If it straddles
  * i_size, adjust end_pos and zero all data beyond i_size.
  */
-static bool iomap_writepage_handle_eof(struct folio *folio, struct inode *inode,
+/*My change:remove static*/
+bool iomap_writepage_handle_eof(struct folio *folio, struct inode *inode,
 		u64 *end_pos)
 {
 	u64 isize = i_size_read(inode);
@@ -1850,7 +1866,7 @@ static bool iomap_writepage_handle_eof(struct folio *folio, struct inode *inode,
 
 	return true;
 }
-
+EXPORT_SYMBOL_GPL(iomap_writepage_handle_eof);
 static int iomap_writepage_map(struct iomap_writepage_ctx *wpc,
 		struct writeback_control *wbc, struct folio *folio)
 {

--- a/fs/iomap/iter.c
+++ b/fs/iomap/iter.c
@@ -27,7 +27,8 @@ int iomap_iter_advance(struct iomap_iter *iter, u64 *count)
 	*count = iomap_length(iter);
 	return 0;
 }
-
+/*Mychange: add export*/
+EXPORT_SYMBOL_GPL(iomap_iter_advance);
 static inline void iomap_iter_done(struct iomap_iter *iter)
 {
 	WARN_ON_ONCE(iter->iomap.offset > iter->pos);
@@ -113,3 +114,5 @@ begin:
 	iomap_iter_done(iter);
 	return 1;
 }
+/*Mychange: add export*/
+EXPORT_SYMBOL_GPL(iomap_iter);


### PR DESCRIPTION
## f2fs iomap支持large folios 初赛代码提交
### commit 1
- 最大的改动。data.c新增的核心函数为`f2fs_buffered_read_iomap_begin`,`f2fs_buffered_write_iomap_begin`,`f2fs_buffered_write_atomic_iomap_begin`,`f2fs_compress_readahead,`f2fs_compress_readpage_iter`.`f2fs_write_cache_folios`,`f2fs_write_single_data_folio`,compress.c中大部分函数改造成支持large folios,新增`f2fs_compress_ctx_add_folio`。因为这个commit被我用`git rebase`给删除了因为vscode的代码自动格式化造成的大量git diff,本来在这次就应该新增加的`f2fs_ifs.h`和`f2fs_ifs.c`被推迟到后面的commit了。
### 最新的commit
- 加了一个自定义编译选项控制打印并且加了一大堆打印信息。因为刚发现page升格到large folios之后竟然在同一个folio之内同时出现了inplace write和outplace write,直接导致`write_bytes_pending`失效。正在想办法解决这个问题。
- 已经发现问题是因为`f2fs_do_write_data_page`中使用了folio结构体导致传入的page,其索引被强行替换成folio的索引也就是头页的索引。因而直接出现问题。